### PR TITLE
Add DataDrivenGoap reference to Unity assembly

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -1231,6 +1231,9 @@
   </ItemGroup>
   <ItemGroup>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="DataDrivenGoap/DataDrivenGoap.csproj" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="GenerateTargetFrameworkMonikerAttribute" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/DataDrivenGoap/DataDrivenGoap.csproj
+++ b/DataDrivenGoap/DataDrivenGoap.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- retarget the DataDrivenGoap library to netstandard2.1 so it can be used by Unity's .NET Framework build
- add a project reference from Assembly-CSharp to DataDrivenGoap so the gameplay demo can compile

## Testing
- not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68df12a6f05483228059f574a842e1dc