### PR TITLE
Avoid tuple usage in world seeding

### DIFF
--- a/Assets/Scripts/GoapDemoSceneController.cs
+++ b/Assets/Scripts/GoapDemoSceneController.cs
@@ -74,7 +74,7 @@ public class GoapDemoSceneController : MonoBehaviour
         var walkable = GenerateWalkableMask(width, height, worldSeed);
         var pawnPositions = ChoosePawnPositions(walkable, pawnCount, worldSeed);
 
-        var seedThings = new List<(ThingId id, string type, IEnumerable<string> tags, GridPos pos, IDictionary<string, double> attrs, BuildingInfo building)>();
+        var seedThings = new List<SeedThing>();
         var random = new System.Random(worldSeed);
 
         for (int i = 0; i < pawnPositions.Count; i++)
@@ -87,7 +87,7 @@ public class GoapDemoSceneController : MonoBehaviour
                 ["energy"] = 0.5 + (random.NextDouble() * 0.5),
                 ["colorIndex"] = i
             };
-            seedThings.Add((id, "villager", tags, pawnPositions[i], attributes, null));
+            seedThings.Add(new SeedThing(id, "villager", tags, pawnPositions[i], attributes, null));
         }
 
         var seedFacts = new List<Fact>();

--- a/DataDrivenGoap/World.SeedThing.cs
+++ b/DataDrivenGoap/World.SeedThing.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace DataDrivenGoap.World
+{
+    /// <summary>
+    /// Helper container used to seed a <see cref="ShardedWorld"/> with initial things.
+    /// </summary>
+    public sealed class SeedThing
+    {
+        public SeedThing(
+            ThingId id,
+            string type,
+            IEnumerable<string> tags,
+            GridPos position,
+            IDictionary<string, double> attributes,
+            BuildingInfo building)
+        {
+            Id = id;
+            Type = type;
+            Tags = tags;
+            Position = position;
+            Attributes = attributes;
+            Building = building;
+        }
+
+        public ThingId Id { get; }
+
+        public string Type { get; }
+
+        public IEnumerable<string> Tags { get; }
+
+        public GridPos Position { get; }
+
+        public IDictionary<string, double> Attributes { get; }
+
+        public BuildingInfo Building { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- replace tuple-based seeding data with a dedicated `SeedThing` type to avoid reliance on value tuples
- update `ShardedWorld` construction and commit bookkeeping to operate on the new container and remove tuple-based helpers

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68df1390d6cc83228c5209d38a77d2aa