### PR TITLE
Ensure Readme assets compile outside the Unity editor

### DIFF
--- a/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
+++ b/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
@@ -1,4 +1,4 @@
-#if UNITY_5_3_OR_NEWER
+#if UNITY_EDITOR
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -240,4 +240,4 @@ public class ReadmeEditor : Editor
         return GUI.Button(position, label, LinkStyle);
     }
 }
-#endif // UNITY_5_3_OR_NEWER
+#endif // UNITY_EDITOR

--- a/Assets/TutorialInfo/Scripts/Readme.cs
+++ b/Assets/TutorialInfo/Scripts/Readme.cs
@@ -1,10 +1,19 @@
-#if UNITY_5_3_OR_NEWER
 using System;
-using UnityEngine;
 
-public class Readme : ScriptableObject
+#if UNITY_5_3_OR_NEWER
+using UnityEngine;
+#endif
+
+public class Readme
+#if UNITY_5_3_OR_NEWER
+    : ScriptableObject
+#endif
 {
+#if UNITY_5_3_OR_NEWER
     public Texture2D icon;
+#else
+    public object icon;
+#endif
     public string title;
     public Section[] sections;
     public bool loadedLayout;
@@ -15,4 +24,3 @@ public class Readme : ScriptableObject
         public string heading, text, linkText, url;
     }
 }
-#endif // UNITY_5_3_OR_NEWER


### PR DESCRIPTION
## Summary
- update the Readme ScriptableObject so that a stub definition is available when Unity-specific symbols are undefined
- guard the Readme editor script behind UNITY_EDITOR to avoid referencing the runtime type in unsupported environments

## Testing
- not run (Unity build environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68df1638417483228a3962807167cf33