### PR TITLE
Fix namespace for tutorial readme editor

### DIFF
--- a/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
+++ b/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
@@ -7,237 +7,232 @@ using System;
 using System.IO;
 using System.Reflection;
 
-[CustomEditor(typeof(Readme))]
-[InitializeOnLoad]
-public class ReadmeEditor : Editor
+namespace TutorialInfo
 {
-    static string s_ShowedReadmeSessionStateName = "ReadmeEditor.showedReadme";
-
-    static string s_ReadmeSourceDirectory = "Assets/TutorialInfo";
-
-    const float k_Space = 16f;
-
-    static ReadmeEditor()
+    [CustomEditor(typeof(Readme))]
+    [InitializeOnLoad]
+    public class ReadmeEditor : Editor
     {
-        EditorApplication.delayCall += SelectReadmeAutomatically;
-    }
+        private const string k_ShowedReadmeSessionStateName = "ReadmeEditor.showedReadme";
+        private const string k_ReadmeSourceDirectory = "Assets/TutorialInfo";
+        private const float k_Space = 16f;
 
-    static void RemoveTutorial()
-    {
-        if (EditorUtility.DisplayDialog("Remove Readme Assets",
-
-            $"All contents under {s_ReadmeSourceDirectory} will be removed, are you sure you want to proceed?",
-            "Proceed",
-            "Cancel"))
+        static ReadmeEditor()
         {
-            if (Directory.Exists(s_ReadmeSourceDirectory))
+            EditorApplication.delayCall += SelectReadmeAutomatically;
+        }
+
+        private static void RemoveTutorial()
+        {
+            if (EditorUtility.DisplayDialog("Remove Readme Assets",
+
+                $"All contents under {k_ReadmeSourceDirectory} will be removed, are you sure you want to proceed?",
+                "Proceed",
+                "Cancel"))
             {
-                FileUtil.DeleteFileOrDirectory(s_ReadmeSourceDirectory);
-                FileUtil.DeleteFileOrDirectory(s_ReadmeSourceDirectory + ".meta");
+                if (Directory.Exists(k_ReadmeSourceDirectory))
+                {
+                    FileUtil.DeleteFileOrDirectory(k_ReadmeSourceDirectory);
+                    FileUtil.DeleteFileOrDirectory(k_ReadmeSourceDirectory + ".meta");
+                }
+                else
+                {
+                    Debug.Log($"Could not find the Readme folder at {k_ReadmeSourceDirectory}");
+                }
+
+                var readmeAsset = SelectReadme();
+                if (readmeAsset != null)
+                {
+                    var path = AssetDatabase.GetAssetPath(readmeAsset);
+                    FileUtil.DeleteFileOrDirectory(path + ".meta");
+                    FileUtil.DeleteFileOrDirectory(path);
+                }
+
+                AssetDatabase.Refresh();
+            }
+        }
+
+        private static void SelectReadmeAutomatically()
+        {
+            if (!SessionState.GetBool(k_ShowedReadmeSessionStateName, false))
+            {
+                var readme = SelectReadme();
+                SessionState.SetBool(k_ShowedReadmeSessionStateName, true);
+
+                if (readme && !readme.loadedLayout)
+                {
+                    LoadLayout();
+                    readme.loadedLayout = true;
+                }
+            }
+        }
+
+        private static void LoadLayout()
+        {
+            var assembly = typeof(EditorApplication).Assembly;
+            var windowLayoutType = assembly.GetType("UnityEditor.WindowLayout", true);
+            var method = windowLayoutType.GetMethod("LoadWindowLayout", BindingFlags.Public | BindingFlags.Static);
+            method.Invoke(null, new object[] { Path.Combine(Application.dataPath, "TutorialInfo/Layout.wlt"), false });
+        }
+
+        private static Readme SelectReadme()
+        {
+            var ids = AssetDatabase.FindAssets("Readme t:Readme");
+            if (ids.Length == 1)
+            {
+                var readmeObject = AssetDatabase.LoadMainAssetAtPath(AssetDatabase.GUIDToAssetPath(ids[0]));
+
+                Selection.objects = new UnityEngine.Object[] { readmeObject };
+
+                return (Readme)readmeObject;
             }
             else
             {
-                Debug.Log($"Could not find the Readme folder at {s_ReadmeSourceDirectory}");
-            }
-
-            var readmeAsset = SelectReadme();
-            if (readmeAsset != null)
-            {
-                var path = AssetDatabase.GetAssetPath(readmeAsset);
-                FileUtil.DeleteFileOrDirectory(path + ".meta");
-                FileUtil.DeleteFileOrDirectory(path);
-            }
-
-            AssetDatabase.Refresh();
-        }
-    }
-
-    static void SelectReadmeAutomatically()
-    {
-        if (!SessionState.GetBool(s_ShowedReadmeSessionStateName, false))
-        {
-            var readme = SelectReadme();
-            SessionState.SetBool(s_ShowedReadmeSessionStateName, true);
-
-            if (readme && !readme.loadedLayout)
-            {
-                LoadLayout();
-                readme.loadedLayout = true;
+                Debug.Log("Couldn't find a readme");
+                return null;
             }
         }
-    }
 
-    static void LoadLayout()
-    {
-        var assembly = typeof(EditorApplication).Assembly;
-        var windowLayoutType = assembly.GetType("UnityEditor.WindowLayout", true);
-        var method = windowLayoutType.GetMethod("LoadWindowLayout", BindingFlags.Public | BindingFlags.Static);
-        method.Invoke(null, new object[] { Path.Combine(Application.dataPath, "TutorialInfo/Layout.wlt"), false });
-    }
-
-    static Readme SelectReadme()
-    {
-        var ids = AssetDatabase.FindAssets("Readme t:Readme");
-        if (ids.Length == 1)
+        protected override void OnHeaderGUI()
         {
-            var readmeObject = AssetDatabase.LoadMainAssetAtPath(AssetDatabase.GUIDToAssetPath(ids[0]));
+            var readme = (Readme)target;
+            Init();
 
-            Selection.objects = new UnityEngine.Object[] { readmeObject };
+            var iconWidth = Mathf.Min(EditorGUIUtility.currentViewWidth / 3f - 20f, 128f);
 
-            return (Readme)readmeObject;
-        }
-        else
-        {
-            Debug.Log("Couldn't find a readme");
-            return null;
-        }
-    }
-
-    protected override void OnHeaderGUI()
-    {
-        var readme = (Readme)target;
-        Init();
-
-        var iconWidth = Mathf.Min(EditorGUIUtility.currentViewWidth / 3f - 20f, 128f);
-
-        GUILayout.BeginHorizontal("In BigTitle");
-        {
-            if (readme.icon != null)
+            GUILayout.BeginHorizontal("In BigTitle");
             {
-                GUILayout.Space(k_Space);
-                GUILayout.Label(readme.icon, GUILayout.Width(iconWidth), GUILayout.Height(iconWidth));
-            }
-            GUILayout.Space(k_Space);
-            GUILayout.BeginVertical();
-            {
-
-                GUILayout.FlexibleSpace();
-                GUILayout.Label(readme.title, TitleStyle);
-                GUILayout.FlexibleSpace();
-            }
-            GUILayout.EndVertical();
-            GUILayout.FlexibleSpace();
-        }
-        GUILayout.EndHorizontal();
-    }
-
-    public override void OnInspectorGUI()
-    {
-        var readme = (Readme)target;
-        Init();
-
-        foreach (var section in readme.sections)
-        {
-            if (!string.IsNullOrEmpty(section.heading))
-            {
-                GUILayout.Label(section.heading, HeadingStyle);
-            }
-
-            if (!string.IsNullOrEmpty(section.text))
-            {
-                GUILayout.Label(section.text, BodyStyle);
-            }
-
-            if (!string.IsNullOrEmpty(section.linkText))
-            {
-                if (LinkLabel(new GUIContent(section.linkText)))
+                if (readme.icon != null)
                 {
-                    Application.OpenURL(section.url);
+                    GUILayout.Space(k_Space);
+                    GUILayout.Label(readme.icon, GUILayout.Width(iconWidth), GUILayout.Height(iconWidth));
                 }
+                GUILayout.Space(k_Space);
+                GUILayout.BeginVertical();
+                {
+
+                    GUILayout.FlexibleSpace();
+                    GUILayout.Label(readme.title, TitleStyle);
+                    GUILayout.FlexibleSpace();
+                }
+                GUILayout.EndVertical();
+                GUILayout.FlexibleSpace();
+            }
+            GUILayout.EndHorizontal();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            var readme = (Readme)target;
+            Init();
+
+            foreach (var section in readme.sections)
+            {
+                if (!string.IsNullOrEmpty(section.heading))
+                {
+                    GUILayout.Label(section.heading, HeadingStyle);
+                }
+
+                if (!string.IsNullOrEmpty(section.text))
+                {
+                    GUILayout.Label(section.text, BodyStyle);
+                }
+
+                if (!string.IsNullOrEmpty(section.linkText))
+                {
+                    if (LinkLabel(new GUIContent(section.linkText)))
+                    {
+                        Application.OpenURL(section.url);
+                    }
+                }
+
+                GUILayout.Space(k_Space);
             }
 
-            GUILayout.Space(k_Space);
+            if (GUILayout.Button("Remove Readme Assets", ButtonStyle))
+            {
+                RemoveTutorial();
+            }
         }
 
-        if (GUILayout.Button("Remove Readme Assets", ButtonStyle))
+        private bool m_Initialized;
+
+        private GUIStyle LinkStyle => m_LinkStyle;
+
+        [SerializeField]
+        private GUIStyle m_LinkStyle;
+
+        private GUIStyle TitleStyle => m_TitleStyle;
+
+        [SerializeField]
+        private GUIStyle m_TitleStyle;
+
+        private GUIStyle HeadingStyle => m_HeadingStyle;
+
+        [SerializeField]
+        private GUIStyle m_HeadingStyle;
+
+        private GUIStyle BodyStyle => m_BodyStyle;
+
+        [SerializeField]
+        private GUIStyle m_BodyStyle;
+
+        private GUIStyle ButtonStyle => m_ButtonStyle;
+
+        [SerializeField]
+        private GUIStyle m_ButtonStyle;
+
+        private void Init()
         {
-            RemoveTutorial();
+            if (m_Initialized)
+                return;
+            m_BodyStyle = new GUIStyle(EditorStyles.label)
+            {
+                wordWrap = true,
+                fontSize = 14,
+                richText = true
+            };
+
+            m_TitleStyle = new GUIStyle(m_BodyStyle)
+            {
+                fontSize = 26
+            };
+
+            m_HeadingStyle = new GUIStyle(m_BodyStyle)
+            {
+                fontStyle = FontStyle.Bold,
+                fontSize = 18
+            };
+
+            m_LinkStyle = new GUIStyle(m_BodyStyle)
+            {
+                wordWrap = false,
+                normal = { textColor = new Color(0x00 / 255f, 0x78 / 255f, 0xDA / 255f, 1f) },
+                stretchWidth = false
+            };
+
+            m_ButtonStyle = new GUIStyle(EditorStyles.miniButton)
+            {
+                fontStyle = FontStyle.Bold
+            };
+
+            m_Initialized = true;
         }
-    }
 
-    bool m_Initialized;
+        private bool LinkLabel(GUIContent label, params GUILayoutOption[] options)
+        {
+            var position = GUILayoutUtility.GetRect(label, LinkStyle, options);
 
-    GUIStyle LinkStyle
-    {
-        get { return m_LinkStyle; }
-    }
+            Handles.BeginGUI();
+            Handles.color = LinkStyle.normal.textColor;
+            Handles.DrawLine(new Vector3(position.xMin, position.yMax), new Vector3(position.xMax, position.yMax));
+            Handles.color = Color.white;
+            Handles.EndGUI();
 
-    [SerializeField]
-    GUIStyle m_LinkStyle;
+            EditorGUIUtility.AddCursorRect(position, MouseCursor.Link);
 
-    GUIStyle TitleStyle
-    {
-        get { return m_TitleStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_TitleStyle;
-
-    GUIStyle HeadingStyle
-    {
-        get { return m_HeadingStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_HeadingStyle;
-
-    GUIStyle BodyStyle
-    {
-        get { return m_BodyStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_BodyStyle;
-
-    GUIStyle ButtonStyle
-    {
-        get { return m_ButtonStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_ButtonStyle;
-
-    void Init()
-    {
-        if (m_Initialized)
-            return;
-        m_BodyStyle = new GUIStyle(EditorStyles.label);
-        m_BodyStyle.wordWrap = true;
-        m_BodyStyle.fontSize = 14;
-        m_BodyStyle.richText = true;
-
-        m_TitleStyle = new GUIStyle(m_BodyStyle);
-        m_TitleStyle.fontSize = 26;
-
-        m_HeadingStyle = new GUIStyle(m_BodyStyle);
-        m_HeadingStyle.fontStyle = FontStyle.Bold;
-        m_HeadingStyle.fontSize = 18;
-
-        m_LinkStyle = new GUIStyle(m_BodyStyle);
-        m_LinkStyle.wordWrap = false;
-        // Match selection color which works nicely for both light and dark skins
-        m_LinkStyle.normal.textColor = new Color(0x00 / 255f, 0x78 / 255f, 0xDA / 255f, 1f);
-        m_LinkStyle.stretchWidth = false;
-
-        m_ButtonStyle = new GUIStyle(EditorStyles.miniButton);
-        m_ButtonStyle.fontStyle = FontStyle.Bold;
-
-        m_Initialized = true;
-    }
-
-    bool LinkLabel(GUIContent label, params GUILayoutOption[] options)
-    {
-        var position = GUILayoutUtility.GetRect(label, LinkStyle, options);
-
-        Handles.BeginGUI();
-        Handles.color = LinkStyle.normal.textColor;
-        Handles.DrawLine(new Vector3(position.xMin, position.yMax), new Vector3(position.xMax, position.yMax));
-        Handles.color = Color.white;
-        Handles.EndGUI();
-
-        EditorGUIUtility.AddCursorRect(position, MouseCursor.Link);
-
-        return GUI.Button(position, label, LinkStyle);
+            return GUI.Button(position, label, LinkStyle);
+        }
     }
 }
 #endif // UNITY_EDITOR

--- a/Assets/TutorialInfo/Scripts/Readme.cs
+++ b/Assets/TutorialInfo/Scripts/Readme.cs
@@ -4,23 +4,26 @@ using System;
 using UnityEngine;
 #endif
 
-public class Readme
-#if UNITY_5_3_OR_NEWER
-    : ScriptableObject
-#endif
+namespace TutorialInfo
 {
+    public class Readme
 #if UNITY_5_3_OR_NEWER
-    public Texture2D icon;
-#else
-    public object icon;
+        : ScriptableObject
 #endif
-    public string title;
-    public Section[] sections;
-    public bool loadedLayout;
-
-    [Serializable]
-    public class Section
     {
-        public string heading, text, linkText, url;
+#if UNITY_5_3_OR_NEWER
+        public Texture2D icon;
+#else
+        public object icon;
+#endif
+        public string title;
+        public Section[] sections;
+        public bool loadedLayout;
+
+        [Serializable]
+        public class Section
+        {
+            public string heading, text, linkText, url;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a shared `TutorialInfo` namespace for the tutorial readme ScriptableObject and its custom editor to keep the type discoverable
- tidy the editor script while moving it into the namespace so it continues to compile cleanly

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_68df172d9fb88322b198f68f6ce50f38