### PR TITLE
Fix DataDrivenGoap compatibility with Unity .NET 4.x

### DIFF
--- a/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
+++ b/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
@@ -7,237 +7,232 @@ using System;
 using System.IO;
 using System.Reflection;
 
-[CustomEditor(typeof(Readme))]
-[InitializeOnLoad]
-public class ReadmeEditor : Editor
+namespace TutorialInfo
 {
-    static string s_ShowedReadmeSessionStateName = "ReadmeEditor.showedReadme";
-
-    static string s_ReadmeSourceDirectory = "Assets/TutorialInfo";
-
-    const float k_Space = 16f;
-
-    static ReadmeEditor()
+    [CustomEditor(typeof(Readme))]
+    [InitializeOnLoad]
+    public class ReadmeEditor : Editor
     {
-        EditorApplication.delayCall += SelectReadmeAutomatically;
-    }
+        private const string k_ShowedReadmeSessionStateName = "ReadmeEditor.showedReadme";
+        private const string k_ReadmeSourceDirectory = "Assets/TutorialInfo";
+        private const float k_Space = 16f;
 
-    static void RemoveTutorial()
-    {
-        if (EditorUtility.DisplayDialog("Remove Readme Assets",
-
-            $"All contents under {s_ReadmeSourceDirectory} will be removed, are you sure you want to proceed?",
-            "Proceed",
-            "Cancel"))
+        static ReadmeEditor()
         {
-            if (Directory.Exists(s_ReadmeSourceDirectory))
+            EditorApplication.delayCall += SelectReadmeAutomatically;
+        }
+
+        private static void RemoveTutorial()
+        {
+            if (EditorUtility.DisplayDialog("Remove Readme Assets",
+
+                $"All contents under {k_ReadmeSourceDirectory} will be removed, are you sure you want to proceed?",
+                "Proceed",
+                "Cancel"))
             {
-                FileUtil.DeleteFileOrDirectory(s_ReadmeSourceDirectory);
-                FileUtil.DeleteFileOrDirectory(s_ReadmeSourceDirectory + ".meta");
+                if (Directory.Exists(k_ReadmeSourceDirectory))
+                {
+                    FileUtil.DeleteFileOrDirectory(k_ReadmeSourceDirectory);
+                    FileUtil.DeleteFileOrDirectory(k_ReadmeSourceDirectory + ".meta");
+                }
+                else
+                {
+                    Debug.Log($"Could not find the Readme folder at {k_ReadmeSourceDirectory}");
+                }
+
+                var readmeAsset = SelectReadme();
+                if (readmeAsset != null)
+                {
+                    var path = AssetDatabase.GetAssetPath(readmeAsset);
+                    FileUtil.DeleteFileOrDirectory(path + ".meta");
+                    FileUtil.DeleteFileOrDirectory(path);
+                }
+
+                AssetDatabase.Refresh();
+            }
+        }
+
+        private static void SelectReadmeAutomatically()
+        {
+            if (!SessionState.GetBool(k_ShowedReadmeSessionStateName, false))
+            {
+                var readme = SelectReadme();
+                SessionState.SetBool(k_ShowedReadmeSessionStateName, true);
+
+                if (readme && !readme.loadedLayout)
+                {
+                    LoadLayout();
+                    readme.loadedLayout = true;
+                }
+            }
+        }
+
+        private static void LoadLayout()
+        {
+            var assembly = typeof(EditorApplication).Assembly;
+            var windowLayoutType = assembly.GetType("UnityEditor.WindowLayout", true);
+            var method = windowLayoutType.GetMethod("LoadWindowLayout", BindingFlags.Public | BindingFlags.Static);
+            method.Invoke(null, new object[] { Path.Combine(Application.dataPath, "TutorialInfo/Layout.wlt"), false });
+        }
+
+        private static Readme SelectReadme()
+        {
+            var ids = AssetDatabase.FindAssets("Readme t:Readme");
+            if (ids.Length == 1)
+            {
+                var readmeObject = AssetDatabase.LoadMainAssetAtPath(AssetDatabase.GUIDToAssetPath(ids[0]));
+
+                Selection.objects = new UnityEngine.Object[] { readmeObject };
+
+                return (Readme)readmeObject;
             }
             else
             {
-                Debug.Log($"Could not find the Readme folder at {s_ReadmeSourceDirectory}");
-            }
-
-            var readmeAsset = SelectReadme();
-            if (readmeAsset != null)
-            {
-                var path = AssetDatabase.GetAssetPath(readmeAsset);
-                FileUtil.DeleteFileOrDirectory(path + ".meta");
-                FileUtil.DeleteFileOrDirectory(path);
-            }
-
-            AssetDatabase.Refresh();
-        }
-    }
-
-    static void SelectReadmeAutomatically()
-    {
-        if (!SessionState.GetBool(s_ShowedReadmeSessionStateName, false))
-        {
-            var readme = SelectReadme();
-            SessionState.SetBool(s_ShowedReadmeSessionStateName, true);
-
-            if (readme && !readme.loadedLayout)
-            {
-                LoadLayout();
-                readme.loadedLayout = true;
+                Debug.Log("Couldn't find a readme");
+                return null;
             }
         }
-    }
 
-    static void LoadLayout()
-    {
-        var assembly = typeof(EditorApplication).Assembly;
-        var windowLayoutType = assembly.GetType("UnityEditor.WindowLayout", true);
-        var method = windowLayoutType.GetMethod("LoadWindowLayout", BindingFlags.Public | BindingFlags.Static);
-        method.Invoke(null, new object[] { Path.Combine(Application.dataPath, "TutorialInfo/Layout.wlt"), false });
-    }
-
-    static Readme SelectReadme()
-    {
-        var ids = AssetDatabase.FindAssets("Readme t:Readme");
-        if (ids.Length == 1)
+        protected override void OnHeaderGUI()
         {
-            var readmeObject = AssetDatabase.LoadMainAssetAtPath(AssetDatabase.GUIDToAssetPath(ids[0]));
+            var readme = (Readme)target;
+            Init();
 
-            Selection.objects = new UnityEngine.Object[] { readmeObject };
+            var iconWidth = Mathf.Min(EditorGUIUtility.currentViewWidth / 3f - 20f, 128f);
 
-            return (Readme)readmeObject;
-        }
-        else
-        {
-            Debug.Log("Couldn't find a readme");
-            return null;
-        }
-    }
-
-    protected override void OnHeaderGUI()
-    {
-        var readme = (Readme)target;
-        Init();
-
-        var iconWidth = Mathf.Min(EditorGUIUtility.currentViewWidth / 3f - 20f, 128f);
-
-        GUILayout.BeginHorizontal("In BigTitle");
-        {
-            if (readme.icon != null)
+            GUILayout.BeginHorizontal("In BigTitle");
             {
-                GUILayout.Space(k_Space);
-                GUILayout.Label(readme.icon, GUILayout.Width(iconWidth), GUILayout.Height(iconWidth));
-            }
-            GUILayout.Space(k_Space);
-            GUILayout.BeginVertical();
-            {
-
-                GUILayout.FlexibleSpace();
-                GUILayout.Label(readme.title, TitleStyle);
-                GUILayout.FlexibleSpace();
-            }
-            GUILayout.EndVertical();
-            GUILayout.FlexibleSpace();
-        }
-        GUILayout.EndHorizontal();
-    }
-
-    public override void OnInspectorGUI()
-    {
-        var readme = (Readme)target;
-        Init();
-
-        foreach (var section in readme.sections)
-        {
-            if (!string.IsNullOrEmpty(section.heading))
-            {
-                GUILayout.Label(section.heading, HeadingStyle);
-            }
-
-            if (!string.IsNullOrEmpty(section.text))
-            {
-                GUILayout.Label(section.text, BodyStyle);
-            }
-
-            if (!string.IsNullOrEmpty(section.linkText))
-            {
-                if (LinkLabel(new GUIContent(section.linkText)))
+                if (readme.icon != null)
                 {
-                    Application.OpenURL(section.url);
+                    GUILayout.Space(k_Space);
+                    GUILayout.Label(readme.icon, GUILayout.Width(iconWidth), GUILayout.Height(iconWidth));
                 }
+                GUILayout.Space(k_Space);
+                GUILayout.BeginVertical();
+                {
+
+                    GUILayout.FlexibleSpace();
+                    GUILayout.Label(readme.title, TitleStyle);
+                    GUILayout.FlexibleSpace();
+                }
+                GUILayout.EndVertical();
+                GUILayout.FlexibleSpace();
+            }
+            GUILayout.EndHorizontal();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            var readme = (Readme)target;
+            Init();
+
+            foreach (var section in readme.sections)
+            {
+                if (!string.IsNullOrEmpty(section.heading))
+                {
+                    GUILayout.Label(section.heading, HeadingStyle);
+                }
+
+                if (!string.IsNullOrEmpty(section.text))
+                {
+                    GUILayout.Label(section.text, BodyStyle);
+                }
+
+                if (!string.IsNullOrEmpty(section.linkText))
+                {
+                    if (LinkLabel(new GUIContent(section.linkText)))
+                    {
+                        Application.OpenURL(section.url);
+                    }
+                }
+
+                GUILayout.Space(k_Space);
             }
 
-            GUILayout.Space(k_Space);
+            if (GUILayout.Button("Remove Readme Assets", ButtonStyle))
+            {
+                RemoveTutorial();
+            }
         }
 
-        if (GUILayout.Button("Remove Readme Assets", ButtonStyle))
+        private bool m_Initialized;
+
+        private GUIStyle LinkStyle => m_LinkStyle;
+
+        [SerializeField]
+        private GUIStyle m_LinkStyle;
+
+        private GUIStyle TitleStyle => m_TitleStyle;
+
+        [SerializeField]
+        private GUIStyle m_TitleStyle;
+
+        private GUIStyle HeadingStyle => m_HeadingStyle;
+
+        [SerializeField]
+        private GUIStyle m_HeadingStyle;
+
+        private GUIStyle BodyStyle => m_BodyStyle;
+
+        [SerializeField]
+        private GUIStyle m_BodyStyle;
+
+        private GUIStyle ButtonStyle => m_ButtonStyle;
+
+        [SerializeField]
+        private GUIStyle m_ButtonStyle;
+
+        private void Init()
         {
-            RemoveTutorial();
+            if (m_Initialized)
+                return;
+            m_BodyStyle = new GUIStyle(EditorStyles.label)
+            {
+                wordWrap = true,
+                fontSize = 14,
+                richText = true
+            };
+
+            m_TitleStyle = new GUIStyle(m_BodyStyle)
+            {
+                fontSize = 26
+            };
+
+            m_HeadingStyle = new GUIStyle(m_BodyStyle)
+            {
+                fontStyle = FontStyle.Bold,
+                fontSize = 18
+            };
+
+            m_LinkStyle = new GUIStyle(m_BodyStyle)
+            {
+                wordWrap = false,
+                normal = { textColor = new Color(0x00 / 255f, 0x78 / 255f, 0xDA / 255f, 1f) },
+                stretchWidth = false
+            };
+
+            m_ButtonStyle = new GUIStyle(EditorStyles.miniButton)
+            {
+                fontStyle = FontStyle.Bold
+            };
+
+            m_Initialized = true;
         }
-    }
 
-    bool m_Initialized;
+        private bool LinkLabel(GUIContent label, params GUILayoutOption[] options)
+        {
+            var position = GUILayoutUtility.GetRect(label, LinkStyle, options);
 
-    GUIStyle LinkStyle
-    {
-        get { return m_LinkStyle; }
-    }
+            Handles.BeginGUI();
+            Handles.color = LinkStyle.normal.textColor;
+            Handles.DrawLine(new Vector3(position.xMin, position.yMax), new Vector3(position.xMax, position.yMax));
+            Handles.color = Color.white;
+            Handles.EndGUI();
 
-    [SerializeField]
-    GUIStyle m_LinkStyle;
+            EditorGUIUtility.AddCursorRect(position, MouseCursor.Link);
 
-    GUIStyle TitleStyle
-    {
-        get { return m_TitleStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_TitleStyle;
-
-    GUIStyle HeadingStyle
-    {
-        get { return m_HeadingStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_HeadingStyle;
-
-    GUIStyle BodyStyle
-    {
-        get { return m_BodyStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_BodyStyle;
-
-    GUIStyle ButtonStyle
-    {
-        get { return m_ButtonStyle; }
-    }
-
-    [SerializeField]
-    GUIStyle m_ButtonStyle;
-
-    void Init()
-    {
-        if (m_Initialized)
-            return;
-        m_BodyStyle = new GUIStyle(EditorStyles.label);
-        m_BodyStyle.wordWrap = true;
-        m_BodyStyle.fontSize = 14;
-        m_BodyStyle.richText = true;
-
-        m_TitleStyle = new GUIStyle(m_BodyStyle);
-        m_TitleStyle.fontSize = 26;
-
-        m_HeadingStyle = new GUIStyle(m_BodyStyle);
-        m_HeadingStyle.fontStyle = FontStyle.Bold;
-        m_HeadingStyle.fontSize = 18;
-
-        m_LinkStyle = new GUIStyle(m_BodyStyle);
-        m_LinkStyle.wordWrap = false;
-        // Match selection color which works nicely for both light and dark skins
-        m_LinkStyle.normal.textColor = new Color(0x00 / 255f, 0x78 / 255f, 0xDA / 255f, 1f);
-        m_LinkStyle.stretchWidth = false;
-
-        m_ButtonStyle = new GUIStyle(EditorStyles.miniButton);
-        m_ButtonStyle.fontStyle = FontStyle.Bold;
-
-        m_Initialized = true;
-    }
-
-    bool LinkLabel(GUIContent label, params GUILayoutOption[] options)
-    {
-        var position = GUILayoutUtility.GetRect(label, LinkStyle, options);
-
-        Handles.BeginGUI();
-        Handles.color = LinkStyle.normal.textColor;
-        Handles.DrawLine(new Vector3(position.xMin, position.yMax), new Vector3(position.xMax, position.yMax));
-        Handles.color = Color.white;
-        Handles.EndGUI();
-
-        EditorGUIUtility.AddCursorRect(position, MouseCursor.Link);
-
-        return GUI.Button(position, label, LinkStyle);
+            return GUI.Button(position, label, LinkStyle);
+        }
     }
 }
 #endif // UNITY_EDITOR

--- a/Assets/TutorialInfo/Scripts/Readme.cs
+++ b/Assets/TutorialInfo/Scripts/Readme.cs
@@ -4,23 +4,26 @@ using System;
 using UnityEngine;
 #endif
 
-public class Readme
-#if UNITY_5_3_OR_NEWER
-    : ScriptableObject
-#endif
+namespace TutorialInfo
 {
+    public class Readme
 #if UNITY_5_3_OR_NEWER
-    public Texture2D icon;
-#else
-    public object icon;
+        : ScriptableObject
 #endif
-    public string title;
-    public Section[] sections;
-    public bool loadedLayout;
-
-    [Serializable]
-    public class Section
     {
-        public string heading, text, linkText, url;
+#if UNITY_5_3_OR_NEWER
+        public Texture2D icon;
+#else
+        public object icon;
+#endif
+        public string title;
+        public Section[] sections;
+        public bool loadedLayout;
+
+        [Serializable]
+        public class Section
+        {
+            public string heading, text, linkText, url;
+        }
     }
 }

--- a/DataDrivenGoap/Compatibility/HashCodeCompat.cs
+++ b/DataDrivenGoap/Compatibility/HashCodeCompat.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace DataDrivenGoap.Compatibility
+{
+    internal static class HashCodeCompat
+    {
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 31 + GetHashCode(value1);
+                hash = hash * 31 + GetHashCode(value2);
+                hash = hash * 31 + GetHashCode(value3);
+                return hash;
+            }
+        }
+
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 31 + GetHashCode(value1);
+                hash = hash * 31 + GetHashCode(value2);
+                hash = hash * 31 + GetHashCode(value3);
+                hash = hash * 31 + GetHashCode(value4);
+                return hash;
+            }
+        }
+
+        private static int GetHashCode<T>(T value)
+        {
+            return value == null ? 0 : EqualityComparer<T>.Default.GetHashCode(value);
+        }
+    }
+}

--- a/DataDrivenGoap/Compatibility/MathUtilities.cs
+++ b/DataDrivenGoap/Compatibility/MathUtilities.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace DataDrivenGoap.Compatibility
+{
+    internal static class MathUtilities
+    {
+        public static double Clamp(double value, double min, double max)
+        {
+            if (min > max)
+            {
+                throw new ArgumentException("min must be less than or equal to max", nameof(min));
+            }
+
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+
+        public static int Clamp(int value, int min, int max)
+        {
+            if (min > max)
+            {
+                throw new ArgumentException("min must be less than or equal to max", nameof(min));
+            }
+
+            if (value < min)
+            {
+                return min;
+            }
+
+            if (value > max)
+            {
+                return max;
+            }
+
+            return value;
+        }
+    }
+}

--- a/DataDrivenGoap/Core.Buildings.cs
+++ b/DataDrivenGoap/Core.Buildings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DataDrivenGoap.Compatibility;
 
 namespace DataDrivenGoap.Core
 {
@@ -33,7 +34,7 @@ namespace DataDrivenGoap.Core
 
         public bool Equals(RectInt other) => MinX == other.MinX && MinY == other.MinY && MaxX == other.MaxX && MaxY == other.MaxY;
         public override bool Equals(object obj) => obj is RectInt r && Equals(r);
-        public override int GetHashCode() => HashCode.Combine(MinX, MinY, MaxX, MaxY);
+        public override int GetHashCode() => HashCodeCompat.Combine(MinX, MinY, MaxX, MaxY);
         public override string ToString() => IsEmpty ? "<empty>" : $"[{MinX},{MinY}]-[{MaxX},{MaxY}]";
     }
 

--- a/DataDrivenGoap/Core.Interfaces.cs
+++ b/DataDrivenGoap/Core.Interfaces.cs
@@ -1,6 +1,7 @@
 
 using System;
 using System.Collections.Generic;
+using DataDrivenGoap.Compatibility;
 using DataDrivenGoap.Items;
 
 namespace DataDrivenGoap.Core
@@ -48,7 +49,7 @@ namespace DataDrivenGoap.Core
         public override string ToString() => $"{Pred}({A},{B})";
         public bool Equals(Fact other) => Pred == other.Pred && A.Equals(other.A) && B.Equals(other.B);
         public override bool Equals(object obj) => obj is Fact f && Equals(f);
-        public override int GetHashCode() => HashCode.Combine(Pred, A, B);
+        public override int GetHashCode() => HashCodeCompat.Combine(Pred, A, B);
     }
 
     public interface IWorldSnapshot

--- a/DataDrivenGoap/DataDrivenGoap.csproj
+++ b/DataDrivenGoap/DataDrivenGoap.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Nullable>disable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Text.Json" Version="6.0.10" />
   </ItemGroup>
 </Project>

--- a/DataDrivenGoap/Expressions.SafeExpr.cs
+++ b/DataDrivenGoap/Expressions.SafeExpr.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using DataDrivenGoap.Compatibility;
 using DataDrivenGoap.Core;
 using DataDrivenGoap.Items;
 
@@ -313,7 +314,7 @@ namespace DataDrivenGoap.Expressions
             {
                 var animal = args.Length > 0 ? AsThingId(args[0], ctx) : AsThingId("$target", ctx);
                 if (ctx?.AnimalQuery != null && ctx.AnimalQuery.TryGet(animal, out var state) && state.Exists)
-                    return Math.Clamp(state.Hunger, 0.0, 1.0);
+                    return MathUtilities.Clamp(state.Hunger, 0.0, 1.0);
                 return 0.0;
             }
 
@@ -329,7 +330,7 @@ namespace DataDrivenGoap.Expressions
             {
                 var animal = args.Length > 0 ? AsThingId(args[0], ctx) : AsThingId("$target", ctx);
                 if (ctx?.AnimalQuery != null && ctx.AnimalQuery.TryGet(animal, out var state) && state.Exists)
-                    return Math.Clamp(state.Happiness, 0.0, 1.0);
+                    return MathUtilities.Clamp(state.Happiness, 0.0, 1.0);
                 return 0.0;
             }
 

--- a/DataDrivenGoap/Simulation.AnimalSystem.cs
+++ b/DataDrivenGoap/Simulation.AnimalSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using DataDrivenGoap.Compatibility;
 using DataDrivenGoap.Config;
 using DataDrivenGoap.Core;
 using DataDrivenGoap.Effects;
@@ -285,8 +286,8 @@ namespace DataDrivenGoap.Simulation
                 state = new AnimalStateSnapshot(
                     true,
                     def.Species,
-                    Math.Clamp(s.Hunger, 0.0, 1.0),
-                    Math.Clamp(s.Happiness, 0.0, 1.0),
+                    MathUtilities.Clamp(s.Hunger, 0.0, 1.0),
+                    MathUtilities.Clamp(s.Happiness, 0.0, 1.0),
                     hasProduce,
                     Math.Max(0.0, minReady),
                     hoursSinceFed,
@@ -383,8 +384,8 @@ namespace DataDrivenGoap.Simulation
                             continue;
                         var s = new AnimalState
                         {
-                            Hunger = Math.Clamp(animal.hunger, 0.0, 1.0),
-                            Happiness = Math.Clamp(animal.happiness, 0.0, 1.0),
+                            Hunger = MathUtilities.Clamp(animal.hunger, 0.0, 1.0),
+                            Happiness = MathUtilities.Clamp(animal.happiness, 0.0, 1.0),
                             LastFedHours = Math.Max(0.0, animal.lastFedHours),
                             LastBrushedHours = Math.Max(0.0, animal.lastBrushedHours),
                             Produce = new List<ProduceState>()
@@ -476,9 +477,9 @@ namespace DataDrivenGoap.Simulation
             if (deltaHours <= 0.0)
                 return;
 
-            state.Hunger = Math.Clamp(state.Hunger + def.HungerRatePerHour * deltaHours, 0.0, 1.0);
+            state.Hunger = MathUtilities.Clamp(state.Hunger + def.HungerRatePerHour * deltaHours, 0.0, 1.0);
             double hungerPenalty = state.Hunger >= 0.8 ? 1.5 : (state.Hunger >= 0.6 ? 1.2 : 1.0);
-            state.Happiness = Math.Clamp(state.Happiness - def.HappinessDecayPerHour * deltaHours * hungerPenalty, 0.0, 1.0);
+            state.Happiness = MathUtilities.Clamp(state.Happiness - def.HappinessDecayPerHour * deltaHours * hungerPenalty, 0.0, 1.0);
 
             if (state.Produce.Count == 0)
                 return;
@@ -524,7 +525,7 @@ namespace DataDrivenGoap.Simulation
                 inventory.Add(new InventoryDelta(operation.Actor, feedItem, quantity, true));
 
             state.Hunger = 0.0;
-            state.Happiness = Math.Clamp(state.Happiness + def.FeedHappinessGain, 0.0, 1.0);
+            state.Happiness = MathUtilities.Clamp(state.Happiness + def.FeedHappinessGain, 0.0, 1.0);
             state.LastFedHours = double.IsNaN(_lastWorldHours) ? 0.0 : _lastWorldHours;
 
             return new AnimalOperationResult(true, inventory, Array.Empty<AnimalProduceYield>());
@@ -536,7 +537,7 @@ namespace DataDrivenGoap.Simulation
             if (now - state.LastBrushedHours < def.BrushCooldownHours - 1e-3)
                 return AnimalOperationResult.Failed;
 
-            state.Happiness = Math.Clamp(state.Happiness + def.BrushHappinessGain, 0.0, 1.0);
+            state.Happiness = MathUtilities.Clamp(state.Happiness + def.BrushHappinessGain, 0.0, 1.0);
             state.LastBrushedHours = now;
             return new AnimalOperationResult(true, Array.Empty<InventoryDelta>(), Array.Empty<AnimalProduceYield>());
         }

--- a/DataDrivenGoap/Simulation.CropSystem.cs
+++ b/DataDrivenGoap/Simulation.CropSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DataDrivenGoap.Compatibility;
 using DataDrivenGoap.Config;
 using DataDrivenGoap.Core;
 using DataDrivenGoap.Effects;
@@ -472,7 +473,7 @@ namespace DataDrivenGoap.Simulation
                 if (hydrated)
                 {
                     state.DaysInStage++;
-                    int index = Math.Clamp(state.Stage, 0, def.StageDurations.Length - 1);
+                    int index = MathUtilities.Clamp(state.Stage, 0, def.StageDurations.Length - 1);
                     int required = def.StageDurations.Length > 0 ? Math.Max(1, def.StageDurations[index]) : 1;
                     if (state.DaysInStage >= required)
                     {

--- a/DataDrivenGoap/Simulation.NeedScheduler.cs
+++ b/DataDrivenGoap/Simulation.NeedScheduler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DataDrivenGoap.Compatibility;
 using System.Threading;
 using DataDrivenGoap.Config;
 using DataDrivenGoap.Core;
@@ -236,7 +237,7 @@ namespace DataDrivenGoap.Simulation
                     double nextValue = currentValue + delta;
                     if (need.Clamp01)
                     {
-                        nextValue = Math.Clamp(nextValue, 0.0, 1.0);
+                        nextValue = MathUtilities.Clamp(nextValue, 0.0, 1.0);
                     }
                     else
                     {

--- a/DataDrivenGoap/Simulation.QuestSystem.cs
+++ b/DataDrivenGoap/Simulation.QuestSystem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using DataDrivenGoap.Compatibility;
 using System.Linq;
 using DataDrivenGoap.Config;
 using DataDrivenGoap.Core;
@@ -206,11 +207,11 @@ namespace DataDrivenGoap.Simulation
             if (state == null || state.Status != QuestStatus.Active)
                 return QuestOperationResult.Failed;
 
-            int index = Math.Clamp(state.ObjectiveIndex, 0, def.Objectives.Length - 1);
+            int index = MathUtilities.Clamp(state.ObjectiveIndex, 0, def.Objectives.Length - 1);
             var objective = def.Objectives[index];
 
             int before = state.Progress;
-            state.Progress = Math.Clamp(state.Progress + amount, 0, objective.Required);
+            state.Progress = MathUtilities.Clamp(state.Progress + amount, 0, objective.Required);
             bool objectiveCompleted = state.Progress >= objective.Required;
             bool stateChanged = state.Progress != before;
 
@@ -385,7 +386,7 @@ namespace DataDrivenGoap.Simulation
                 }
                 else
                 {
-                    index = Math.Clamp(state?.ObjectiveIndex ?? 0, 0, def.Objectives.Length - 1);
+                    index = MathUtilities.Clamp(state?.ObjectiveIndex ?? 0, 0, def.Objectives.Length - 1);
                 }
 
                 var objective = def.Objectives[index];
@@ -420,7 +421,7 @@ namespace DataDrivenGoap.Simulation
                     }
                     else if (index == state.ObjectiveIndex)
                     {
-                        progress = Math.Clamp(state.Progress, 0, objective.Required);
+                        progress = MathUtilities.Clamp(state.Progress, 0, objective.Required);
                         completed = progress >= objective.Required;
                         isCurrent = state.Status == QuestStatus.Active;
                     }

--- a/DataDrivenGoap/Social.RelationshipSystem.cs
+++ b/DataDrivenGoap/Social.RelationshipSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using DataDrivenGoap.Compatibility;
 using DataDrivenGoap.Config;
 using DataDrivenGoap.Core;
 using DataDrivenGoap.Effects;
@@ -154,7 +155,7 @@ namespace DataDrivenGoap.Social
                 }
 
                 TryGetRelationshipValue(fromThing, def, to, out var current);
-                double targetValue = Math.Clamp(projector(current), def.MinValue, def.MaxValue);
+                double targetValue = MathUtilities.Clamp(projector(current), def.MinValue, def.MaxValue);
                 if (Math.Abs(targetValue - current) < 1e-6)
                 {
                     return targetValue;
@@ -172,7 +173,7 @@ namespace DataDrivenGoap.Social
                 if (def.Symmetric)
                 {
                     TryGetRelationshipValue(toThing, def, from, out var reverseCurrent);
-                    double reverseTarget = Math.Clamp(projector(reverseCurrent), def.MinValue, def.MaxValue);
+                    double reverseTarget = MathUtilities.Clamp(projector(reverseCurrent), def.MinValue, def.MaxValue);
                     if (Math.Abs(reverseTarget - reverseCurrent) >= 1e-6)
                     {
                         writes.Add(new WriteSetEntry(to, BuildAttributeKey(def.Id, from), reverseTarget));
@@ -246,7 +247,7 @@ namespace DataDrivenGoap.Social
             var key = BuildAttributeKey(def.Id, target);
             if (thing.Attributes.TryGetValue(key, out var existing))
             {
-                value = Math.Clamp(existing, def.MinValue, def.MaxValue);
+                value = MathUtilities.Clamp(existing, def.MinValue, def.MaxValue);
                 return true;
             }
 


### PR DESCRIPTION
## Summary
- retarget the DataDrivenGoap project to build for both netstandard2.1 and netstandard2.0 with package versions Unity can consume
- add compatibility helpers that provide Math.Clamp and HashCode.Combine equivalents when running on .NET Framework
- update GOAP systems to use the compatibility helpers so the Unity editor build no longer fails to resolve the Readme type or the project reference

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df172d9fb88322b198f68f6ce50f38