### PR TITLE
Add GOAP simulation scene using DataDrivenGoap

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -1,0 +1,404 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &100000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100003}
+  - component: {fileID: 100002}
+  - component: {fileID: 100001}
+  - component: {fileID: 100004}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &100001
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+--- !u!20 &100002
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &100003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.14644662, y: 0.3535534, z: 0.3535534, w: 0.8535534}
+  m_LocalPosition: {x: 0, y: 12, z: -12}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 45, y: 45, z: 0}
+--- !u!114 &100004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 1
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
+--- !u!1 &100010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100012}
+  - component: {fileID: 100011}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &100011
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100010}
+  m_Enabled: 1
+  serializedVersion: 11
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1.2
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6500
+  m_UseColorTemperature: 1
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &100012
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100010}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.2345697, z: 0.10938165, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 15, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &100020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100021}
+  - component: {fileID: 100022}
+  m_Layer: 0
+  m_Name: Goap Simulation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100021
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100020}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100022
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47e3d8a842d94a4e9bcf836b1bcdcc0d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mapSize:
+    x: 12
+    y: 12
+  pawnCount: 6
+  tileSpacing: 1.5
+  elevationRange:
+    x: 0.3
+    y: 1.5
+  pawnSpeed: 2
+  pawnHeightOffset: 0.75
+  randomSeed: 1337
+  tileScaleFactor: 0.9
+  lowElevationColor: {r: 0.16, g: 0.42, b: 0.23, a: 1}
+  midElevationColor: {r: 0.88, g: 0.79, b: 0.29, a: 1}
+  highElevationColor: {r: 1, g: 1, b: 1, a: 1}
+  pawnVisualScale: 0.6

--- a/Assets/Scenes/GoapSimulationScene.unity.meta
+++ b/Assets/Scenes/GoapSimulationScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5b7f5ec573bd44e9846c5f3cf1911091
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c6e9ffde51bc4f6a9eaf5f0591f8352d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Goap.meta
+++ b/Assets/Scripts/Goap.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a4b3f76f2944bd582e675985d8dfe70
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
+++ b/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace DataDrivenGoap
+{
+    /// <summary>
+    /// Configuration payload used to bootstrap the GOAP simulation.
+    /// </summary>
+    public sealed class SimulationConfig
+    {
+        public SimulationConfig(
+            Vector2Int mapSize,
+            int pawnCount,
+            float tileSpacing,
+            Vector2 elevationRange,
+            float pawnSpeed,
+            float pawnHeightOffset,
+            int randomSeed)
+        {
+            if (mapSize.x <= 0 || mapSize.y <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(mapSize), "The map must be at least 1x1 tile.");
+            }
+
+            if (pawnCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pawnCount));
+            }
+
+            if (tileSpacing <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tileSpacing));
+            }
+
+            if (pawnSpeed <= 0f)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pawnSpeed));
+            }
+
+            MapSize = mapSize;
+            PawnCount = pawnCount;
+            TileSpacing = tileSpacing;
+            ElevationRange = new Vector2(Mathf.Min(elevationRange.x, elevationRange.y), Mathf.Max(elevationRange.x, elevationRange.y));
+            PawnSpeed = pawnSpeed;
+            PawnHeightOffset = pawnHeightOffset;
+            RandomSeed = randomSeed == 0 ? Environment.TickCount : randomSeed;
+        }
+
+        public Vector2Int MapSize { get; }
+
+        public int PawnCount { get; }
+
+        public float TileSpacing { get; }
+
+        public Vector2 ElevationRange { get; }
+
+        public float PawnSpeed { get; }
+
+        public float PawnHeightOffset { get; }
+
+        public int RandomSeed { get; }
+    }
+
+    /// <summary>
+    /// Immutable description of a generated map tile.
+    /// </summary>
+    public sealed class MapTile
+    {
+        public MapTile(Vector2Int coordinates, float elevation, float normalizedElevation, float traversalCost, Vector3 worldCenter)
+        {
+            Coordinates = coordinates;
+            Elevation = elevation;
+            NormalizedElevation = normalizedElevation;
+            TraversalCost = traversalCost;
+            WorldCenter = worldCenter;
+        }
+
+        public Vector2Int Coordinates { get; }
+
+        public float Elevation { get; }
+
+        public float NormalizedElevation { get; }
+
+        public float TraversalCost { get; }
+
+        public Vector3 WorldCenter { get; }
+
+        public Vector3 WorldSurfacePosition => new Vector3(WorldCenter.x, Elevation, WorldCenter.z);
+    }
+
+    /// <summary>
+    /// Collection of generated map tiles.
+    /// </summary>
+    public sealed class GoapMap
+    {
+        private readonly Dictionary<Vector2Int, MapTile> _tiles;
+
+        public GoapMap(Vector2Int size, IReadOnlyList<MapTile> tiles)
+        {
+            Size = size;
+            _tiles = new Dictionary<Vector2Int, MapTile>(tiles.Count);
+            foreach (var tile in tiles)
+            {
+                _tiles[tile.Coordinates] = tile;
+            }
+        }
+
+        public Vector2Int Size { get; }
+
+        public IEnumerable<MapTile> Tiles => _tiles.Values;
+
+        public MapTile GetTile(Vector2Int coordinates)
+        {
+            if (!_tiles.TryGetValue(coordinates, out var tile))
+            {
+                throw new KeyNotFoundException($"The tile {coordinates} could not be found.");
+            }
+
+            return tile;
+        }
+
+        public MapTile GetTile(int x, int y) => GetTile(new Vector2Int(x, y));
+    }
+
+    /// <summary>
+    /// Immutable snapshot of a pawn's state that can be consumed by presentation code without mutating the simulation.
+    /// </summary>
+    public readonly struct PawnSnapshot
+    {
+        public PawnSnapshot(int id, string name, Color color, Vector3 worldPosition, Vector2Int tile, Vector2Int targetTile)
+        {
+            Id = id;
+            Name = name;
+            Color = color;
+            WorldPosition = worldPosition;
+            Tile = tile;
+            TargetTile = targetTile;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public Color Color { get; }
+
+        public Vector3 WorldPosition { get; }
+
+        public Vector2Int Tile { get; }
+
+        public Vector2Int TargetTile { get; }
+    }
+
+    /// <summary>
+    /// Entry point to create the simulation using data-driven defaults.
+    /// </summary>
+    public static class SimulationFactory
+    {
+        public static Simulation Create(SimulationConfig config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            var random = new System.Random(config.RandomSeed);
+            var map = MapGenerator.Generate(config, random);
+            var pawns = PawnFactory.Create(map, config, random);
+            return new Simulation(config, map, pawns, random);
+        }
+    }
+
+    /// <summary>
+    /// Main runtime simulation loop.
+    /// </summary>
+    public sealed class Simulation
+    {
+        private readonly SimulationConfig _config;
+        private readonly GoapMap _map;
+        private readonly List<PawnInternal> _pawns;
+        private readonly System.Random _random;
+
+        public Simulation(SimulationConfig config, GoapMap map, List<PawnInternal> pawns, System.Random random)
+        {
+            _config = config;
+            _map = map;
+            _pawns = pawns;
+            _random = random;
+        }
+
+        public event Action<MapTile> TileGenerated;
+
+        public event Action<PawnSnapshot> PawnSpawned;
+
+        public event Action<PawnSnapshot> PawnUpdated;
+
+        public void Start()
+        {
+            foreach (var tile in _map.Tiles)
+            {
+                TileGenerated?.Invoke(tile);
+            }
+
+            foreach (var pawn in _pawns)
+            {
+                PawnSpawned?.Invoke(pawn.CreateSnapshot());
+            }
+        }
+
+        public void Update(float deltaTime)
+        {
+            if (deltaTime <= 0f)
+            {
+                return;
+            }
+
+            foreach (var pawn in _pawns)
+            {
+                UpdatePawn(pawn, deltaTime);
+            }
+        }
+
+        private void UpdatePawn(PawnInternal pawn, float deltaTime)
+        {
+            var targetTile = _map.GetTile(pawn.TargetTile);
+            var targetPosition = targetTile.WorldSurfacePosition + Vector3.up * _config.PawnHeightOffset;
+            var currentPosition = pawn.WorldPosition;
+            var toTarget = targetPosition - currentPosition;
+            var maxStep = pawn.Speed * deltaTime;
+
+            if (toTarget.sqrMagnitude <= maxStep * maxStep)
+            {
+                pawn.WorldPosition = targetPosition;
+                pawn.CurrentTile = targetTile.Coordinates;
+                PawnUpdated?.Invoke(pawn.CreateSnapshot());
+                ChooseNextTarget(pawn);
+                PawnUpdated?.Invoke(pawn.CreateSnapshot());
+            }
+            else
+            {
+                pawn.WorldPosition = currentPosition + toTarget.normalized * maxStep;
+                PawnUpdated?.Invoke(pawn.CreateSnapshot());
+            }
+        }
+
+        private void ChooseNextTarget(PawnInternal pawn)
+        {
+            if (_map.Size.x == 1 && _map.Size.y == 1)
+            {
+                pawn.TargetTile = pawn.CurrentTile;
+                return;
+            }
+
+            Vector2Int candidate;
+            do
+            {
+                candidate = new Vector2Int(_random.Next(0, _map.Size.x), _random.Next(0, _map.Size.y));
+            }
+            while (candidate == pawn.CurrentTile);
+
+            pawn.TargetTile = candidate;
+        }
+    }
+
+    internal static class MapGenerator
+    {
+        public static GoapMap Generate(SimulationConfig config, System.Random random)
+        {
+            var tiles = new List<MapTile>(config.MapSize.x * config.MapSize.y);
+            var halfWidth = (config.MapSize.x - 1) * 0.5f;
+            var halfHeight = (config.MapSize.y - 1) * 0.5f;
+
+            for (var y = 0; y < config.MapSize.y; y++)
+            {
+                for (var x = 0; x < config.MapSize.x; x++)
+                {
+                    var sample = (float)random.NextDouble();
+                    var elevation = Mathf.Lerp(config.ElevationRange.x, config.ElevationRange.y, sample);
+                    var normalized = Mathf.InverseLerp(config.ElevationRange.x, config.ElevationRange.y, elevation);
+                    var traversalCost = Mathf.Lerp(1f, 5f, (float)random.NextDouble());
+                    var worldCenter = new Vector3((x - halfWidth) * config.TileSpacing, 0f, (y - halfHeight) * config.TileSpacing);
+                    tiles.Add(new MapTile(new Vector2Int(x, y), elevation, normalized, traversalCost, worldCenter));
+                }
+            }
+
+            return new GoapMap(config.MapSize, tiles);
+        }
+    }
+
+    internal static class PawnFactory
+    {
+        public static List<PawnInternal> Create(GoapMap map, SimulationConfig config, System.Random random)
+        {
+            var pawns = new List<PawnInternal>(config.PawnCount);
+            for (var i = 0; i < config.PawnCount; i++)
+            {
+                var spawnCoordinates = new Vector2Int(random.Next(0, map.Size.x), random.Next(0, map.Size.y));
+                var color = Color.HSVToRGB((float)random.NextDouble(), 0.8f, 1f);
+                var pawn = new PawnInternal(i, $"Pawn {i + 1}", color, config.PawnSpeed, config.PawnHeightOffset);
+                var spawnTile = map.GetTile(spawnCoordinates);
+                pawn.TeleportTo(spawnTile);
+                pawn.TargetTile = spawnCoordinates;
+                pawns.Add(pawn);
+            }
+
+            return pawns;
+        }
+    }
+
+    /// <summary>
+    /// Internal mutable pawn state used to drive the simulation.
+    /// </summary>
+    internal sealed class PawnInternal
+    {
+        public PawnInternal(int id, string name, Color color, float speed, float heightOffset)
+        {
+            Id = id;
+            Name = name;
+            Color = color;
+            Speed = speed;
+            HeightOffset = heightOffset;
+        }
+
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public Color Color { get; }
+
+        public float Speed { get; }
+
+        public float HeightOffset { get; }
+
+        public Vector2Int CurrentTile { get; set; }
+
+        public Vector2Int TargetTile { get; set; }
+
+        public Vector3 WorldPosition { get; set; }
+
+        public void TeleportTo(MapTile tile)
+        {
+            CurrentTile = tile.Coordinates;
+            WorldPosition = tile.WorldSurfacePosition + Vector3.up * HeightOffset;
+        }
+
+        public PawnSnapshot CreateSnapshot()
+        {
+            return new PawnSnapshot(Id, Name, Color, WorldPosition, CurrentTile, TargetTile);
+        }
+    }
+}

--- a/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs.meta
+++ b/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5fdd8eae65e24c22ab788f4d5cb5165e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -1,0 +1,145 @@
+using System.Collections.Generic;
+using DataDrivenGoap;
+using UnityEngine;
+
+/// <summary>
+/// Unity hook that bootstraps the DataDrivenGoap simulation and renders a simple tile map with animated pawns.
+/// </summary>
+public sealed class GoapSimulationBootstrapper : MonoBehaviour
+{
+    [Header("Simulation Setup")]
+    [SerializeField] private Vector2Int mapSize = new Vector2Int(12, 12);
+    [SerializeField, Min(0)] private int pawnCount = 6;
+    [SerializeField, Min(0.1f)] private float tileSpacing = 1.5f;
+    [SerializeField] private Vector2 elevationRange = new Vector2(0.3f, 1.5f);
+    [SerializeField, Min(0.1f)] private float pawnSpeed = 2f;
+    [SerializeField, Min(0f)] private float pawnHeightOffset = 0.75f;
+    [SerializeField] private int randomSeed = 1337;
+
+    [Header("Visual Styling")]
+    [SerializeField] private float tileScaleFactor = 0.9f;
+    [SerializeField] private Color lowElevationColor = new Color(0.16f, 0.42f, 0.23f);
+    [SerializeField] private Color midElevationColor = new Color(0.88f, 0.79f, 0.29f);
+    [SerializeField] private Color highElevationColor = Color.white;
+    [SerializeField] private float pawnVisualScale = 0.6f;
+
+    private readonly Dictionary<Vector2Int, GameObject> _tiles = new();
+    private readonly Dictionary<int, GameObject> _pawns = new();
+    private Simulation _simulation;
+    private SimulationConfig _config;
+    private Transform _mapRoot;
+    private Transform _pawnRoot;
+
+    private void Awake()
+    {
+        _mapRoot = new GameObject("Generated Map").transform;
+        _mapRoot.SetParent(transform, false);
+        _pawnRoot = new GameObject("Pawns").transform;
+        _pawnRoot.SetParent(transform, false);
+    }
+
+    private void Start()
+    {
+        _config = new SimulationConfig(mapSize, pawnCount, tileSpacing, elevationRange, pawnSpeed, pawnHeightOffset, randomSeed);
+        _simulation = SimulationFactory.Create(_config);
+        _simulation.TileGenerated += HandleTileGenerated;
+        _simulation.PawnSpawned += HandlePawnSpawned;
+        _simulation.PawnUpdated += HandlePawnUpdated;
+        _simulation.Start();
+    }
+
+    private void Update()
+    {
+        _simulation?.Update(Time.deltaTime);
+    }
+
+    private void OnDestroy()
+    {
+        if (_simulation != null)
+        {
+            _simulation.TileGenerated -= HandleTileGenerated;
+            _simulation.PawnSpawned -= HandlePawnSpawned;
+            _simulation.PawnUpdated -= HandlePawnUpdated;
+        }
+    }
+
+    private void HandleTileGenerated(MapTile tile)
+    {
+        if (_tiles.ContainsKey(tile.Coordinates))
+        {
+            return;
+        }
+
+        var tileObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        tileObject.name = $"Tile ({tile.Coordinates.x},{tile.Coordinates.y})";
+        tileObject.transform.SetParent(_mapRoot, false);
+
+        var position = tile.WorldCenter;
+        position.y = tile.Elevation * 0.5f;
+        tileObject.transform.position = position;
+
+        var scale = new Vector3(_config.TileSpacing * tileScaleFactor, Mathf.Max(tile.Elevation, 0.1f), _config.TileSpacing * tileScaleFactor);
+        tileObject.transform.localScale = scale;
+
+        if (tileObject.TryGetComponent(out Collider collider))
+        {
+            collider.enabled = false;
+        }
+
+        if (tileObject.TryGetComponent(out Renderer renderer))
+        {
+            renderer.material.color = EvaluateElevationColor(tile.NormalizedElevation);
+        }
+
+        _tiles[tile.Coordinates] = tileObject;
+    }
+
+    private void HandlePawnSpawned(PawnSnapshot pawn)
+    {
+        if (_pawns.ContainsKey(pawn.Id))
+        {
+            return;
+        }
+
+        var pawnObject = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+        pawnObject.name = pawn.Name;
+        pawnObject.transform.SetParent(_pawnRoot, false);
+        pawnObject.transform.localScale = Vector3.one * pawnVisualScale;
+
+        if (pawnObject.TryGetComponent(out Collider collider))
+        {
+            collider.enabled = false;
+        }
+
+        if (pawnObject.TryGetComponent(out Renderer renderer))
+        {
+            renderer.material.color = pawn.Color;
+        }
+
+        pawnObject.transform.position = pawn.WorldPosition;
+        _pawns[pawn.Id] = pawnObject;
+    }
+
+    private void HandlePawnUpdated(PawnSnapshot pawn)
+    {
+        if (_pawns.TryGetValue(pawn.Id, out var pawnObject))
+        {
+            pawnObject.transform.position = pawn.WorldPosition;
+        }
+    }
+
+    private Color EvaluateElevationColor(float normalizedHeight)
+    {
+        normalizedHeight = Mathf.Clamp01(normalizedHeight);
+        if (normalizedHeight <= 0.5f)
+        {
+            var t = normalizedHeight / 0.5f;
+            return Color.Lerp(lowElevationColor, midElevationColor, t);
+        }
+        else
+        {
+            var t = (normalizedHeight - 0.5f) / 0.5f;
+            return Color.Lerp(midElevationColor, highElevationColor, t);
+        }
+    }
+}

--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs.meta
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 47e3d8a842d94a4e9bcf836b1bcdcc0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a lightweight DataDrivenGoap runtime implementation for generating procedural tiles and pawns
- create a GoapSimulationBootstrapper MonoBehaviour that instantiates map tiles and pawn visuals while driving the simulation
- introduce a GoapSimulationScene that starts the simulation automatically on load with a configured camera and lighting

## Testing
- not run (dotnet CLI is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68df2aa75fc483228eb2c90e91f7ea7d