### PR TITLE
Expose GOAP runtime data in scene

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -412,6 +412,7 @@ GameObject:
   m_Component:
   - component: {fileID: 100021}
   - component: {fileID: 100022}
+  - component: {fileID: 100023}
   m_Layer: 0
   m_Name: Goap Simulation
   m_TagString: Untagged
@@ -458,6 +459,19 @@ MonoBehaviour:
   midElevationColor: {r: 0.88, g: 0.79, b: 0.29, a: 1}
   highElevationColor: {r: 1, g: 1, b: 1, a: 1}
   pawnVisualScale: 0.6
+--- !u!114 &100023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 94ae767f64b544fd8a74a2c484d2b7bc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bootstrapper: {fileID: 100022}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
+++ b/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
@@ -194,6 +194,10 @@ namespace DataDrivenGoap
 
         public event Action<PawnSnapshot> PawnUpdated;
 
+        public SimulationConfig Config => _config;
+
+        public GoapMap Map => _map;
+
         public void Start()
         {
             foreach (var tile in _map.Tiles)
@@ -259,6 +263,29 @@ namespace DataDrivenGoap
             while (candidate == pawn.CurrentTile);
 
             pawn.TargetTile = candidate;
+        }
+
+        public IEnumerable<PawnSnapshot> GetPawnSnapshots()
+        {
+            foreach (var pawn in _pawns)
+            {
+                yield return pawn.CreateSnapshot();
+            }
+        }
+
+        public bool TryGetPawnSnapshot(int id, out PawnSnapshot snapshot)
+        {
+            foreach (var pawn in _pawns)
+            {
+                if (pawn.Id == id)
+                {
+                    snapshot = pawn.CreateSnapshot();
+                    return true;
+                }
+            }
+
+            snapshot = default;
+            return false;
         }
     }
 

--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using DataDrivenGoap;
 using UnityEngine;
@@ -34,6 +35,18 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
     private Sprite _pawnSprite;
     private Texture2D _pawnTexture;
 
+    public event Action<Simulation> SimulationInitialized;
+
+    public Simulation Simulation => _simulation;
+
+    public SimulationConfig Config => _config;
+
+    public IReadOnlyDictionary<Vector2Int, GameObject> TileObjects => _tiles;
+
+    public IReadOnlyDictionary<int, GameObject> PawnObjects => _pawns;
+
+    public IReadOnlyDictionary<int, PawnSnapshot> CurrentPawnSnapshots => _pawnSnapshots;
+
     private void Awake()
     {
         _mapRoot = new GameObject("Generated Map").transform;
@@ -54,6 +67,8 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
         _simulation.PawnUpdated += HandlePawnUpdated;
         _simulation.Start();
 
+        SimulationInitialized?.Invoke(_simulation);
+
         Debug.Log(
             $"GOAP simulation started with world {mapSize.x}x{mapSize.y}, {pawnCount} pawns, tile spacing {tileSpacing:F2}, elevation range {elevationRange.x:F2}-{elevationRange.y:F2}, pawn speed {pawnSpeed:F2}, height offset {pawnHeightOffset:F2} (seed {randomSeed}).");
 
@@ -72,6 +87,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
             _simulation.TileGenerated -= HandleTileGenerated;
             _simulation.PawnSpawned -= HandlePawnSpawned;
             _simulation.PawnUpdated -= HandlePawnUpdated;
+            SimulationInitialized = null;
         }
 
         if (_pawnTexture != null)
@@ -246,3 +262,4 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
         return Sprite.Create(_pawnTexture, new Rect(0f, 0f, size, size), new Vector2(0.5f, 0.5f), size);
     }
 }
+

--- a/Assets/Scripts/Goap/GoapSimulationSceneModel.cs
+++ b/Assets/Scripts/Goap/GoapSimulationSceneModel.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using DataDrivenGoap;
+using UnityEngine;
+
+/// <summary>
+/// Captures the core DataDrivenGoap runtime types so that other systems (such as UI)
+/// can observe the simulation from the scene hierarchy.
+/// </summary>
+public sealed class GoapSimulationSceneModel : MonoBehaviour
+{
+    [Header("Dependencies")]
+    [SerializeField] private GoapSimulationBootstrapper bootstrapper;
+
+    private readonly List<MapTile> _mapTiles = new();
+    private readonly List<PawnSnapshot> _pawnSnapshots = new();
+
+    public SimulationConfig Config { get; private set; }
+
+    public Simulation Simulation { get; private set; }
+
+    public IReadOnlyList<MapTile> MapTiles => _mapTiles;
+
+    public IReadOnlyList<PawnSnapshot> PawnSnapshots => _pawnSnapshots;
+
+    private void Reset()
+    {
+        bootstrapper = GetComponent<GoapSimulationBootstrapper>();
+    }
+
+    private void Awake()
+    {
+        if (bootstrapper == null)
+        {
+            bootstrapper = GetComponent<GoapSimulationBootstrapper>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (bootstrapper == null)
+        {
+            return;
+        }
+
+        bootstrapper.SimulationInitialized += HandleSimulationInitialized;
+
+        if (bootstrapper.Simulation != null)
+        {
+            HandleSimulationInitialized(bootstrapper.Simulation);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (bootstrapper != null)
+        {
+            bootstrapper.SimulationInitialized -= HandleSimulationInitialized;
+        }
+
+        if (Simulation != null)
+        {
+            UnsubscribeFromSimulation(Simulation);
+            Simulation = null;
+        }
+    }
+
+    public bool TryGetMapTile(Vector2Int coordinates, out MapTile tile)
+    {
+        for (var i = 0; i < _mapTiles.Count; i++)
+        {
+            if (_mapTiles[i].Coordinates == coordinates)
+            {
+                tile = _mapTiles[i];
+                return true;
+            }
+        }
+
+        tile = null;
+        return false;
+    }
+
+    public bool TryGetPawnSnapshot(int id, out PawnSnapshot snapshot)
+    {
+        for (var i = 0; i < _pawnSnapshots.Count; i++)
+        {
+            if (_pawnSnapshots[i].Id == id)
+            {
+                snapshot = _pawnSnapshots[i];
+                return true;
+            }
+        }
+
+        snapshot = default;
+        return false;
+    }
+
+    private void HandleSimulationInitialized(Simulation simulation)
+    {
+        if (simulation == null)
+        {
+            return;
+        }
+
+        if (Simulation != null)
+        {
+            UnsubscribeFromSimulation(Simulation);
+        }
+
+        Simulation = simulation;
+        Config = simulation.Config;
+
+        _mapTiles.Clear();
+        foreach (var tile in simulation.Map.Tiles)
+        {
+            _mapTiles.Add(tile);
+        }
+
+        _pawnSnapshots.Clear();
+        foreach (var pawn in simulation.GetPawnSnapshots())
+        {
+            _pawnSnapshots.Add(pawn);
+        }
+
+        SubscribeToSimulation(simulation);
+    }
+
+    private void SubscribeToSimulation(Simulation simulation)
+    {
+        simulation.TileGenerated += HandleTileGenerated;
+        simulation.PawnSpawned += HandlePawnChanged;
+        simulation.PawnUpdated += HandlePawnChanged;
+    }
+
+    private void UnsubscribeFromSimulation(Simulation simulation)
+    {
+        simulation.TileGenerated -= HandleTileGenerated;
+        simulation.PawnSpawned -= HandlePawnChanged;
+        simulation.PawnUpdated -= HandlePawnChanged;
+    }
+
+    private void HandleTileGenerated(MapTile tile)
+    {
+        for (var i = 0; i < _mapTiles.Count; i++)
+        {
+            if (_mapTiles[i].Coordinates == tile.Coordinates)
+            {
+                _mapTiles[i] = tile;
+                return;
+            }
+        }
+
+        _mapTiles.Add(tile);
+    }
+
+    private void HandlePawnChanged(PawnSnapshot pawn)
+    {
+        for (var i = 0; i < _pawnSnapshots.Count; i++)
+        {
+            if (_pawnSnapshots[i].Id == pawn.Id)
+            {
+                _pawnSnapshots[i] = pawn;
+                return;
+            }
+        }
+
+        _pawnSnapshots.Add(pawn);
+    }
+}

--- a/Assets/Scripts/Goap/GoapSimulationSceneModel.cs.meta
+++ b/Assets/Scripts/Goap/GoapSimulationSceneModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94ae767f64b544fd8a74a2c484d2b7bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- expose the simulation configuration, map and pawn snapshots from the DataDrivenGoap runtime
- publish the bootstrapper runtime data so other scene components can observe the simulation
- add a GoapSimulationSceneModel component in the GOAP scene to capture the shared data for future UI work

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68df3aa9cb548322bbc7eadd01539d25