### PR TITLE
Load GOAP simulation definitions from JSON assets

### DIFF
--- a/Assets/Scripts/Goap/DataDrivenGoapJsonLoader.cs
+++ b/Assets/Scripts/Goap/DataDrivenGoapJsonLoader.cs
@@ -1,0 +1,185 @@
+using System;
+using UnityEngine;
+
+namespace DataDrivenGoap
+{
+    /// <summary>
+    /// Utility responsible for converting JSON payloads into strongly typed GOAP definitions.
+    /// </summary>
+    public static class DataDrivenGoapJsonLoader
+    {
+        public static MapDefinitionDto LoadMapDefinition(TextAsset asset)
+        {
+            if (asset == null)
+            {
+                throw new ArgumentNullException(nameof(asset));
+            }
+
+            var definition = JsonUtility.FromJson<MapDefinitionDto>(asset.text);
+            if (definition == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize the map definition payload.");
+            }
+
+            definition.ApplyDefaults();
+            return definition;
+        }
+
+        public static PawnDefinitionsDto LoadPawnDefinitions(TextAsset asset)
+        {
+            if (asset == null)
+            {
+                throw new ArgumentNullException(nameof(asset));
+            }
+
+            var definition = JsonUtility.FromJson<PawnDefinitionsDto>(asset.text);
+            if (definition == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize the pawn definition payload.");
+            }
+
+            definition.ApplyDefaults();
+            return definition;
+        }
+
+        public static ItemDefinitionsDto LoadItemDefinitions(TextAsset asset)
+        {
+            if (asset == null)
+            {
+                throw new ArgumentNullException(nameof(asset));
+            }
+
+            if (string.IsNullOrWhiteSpace(asset.text))
+            {
+                return ItemDefinitionsDto.Empty;
+            }
+
+            var definition = JsonUtility.FromJson<ItemDefinitionsDto>(asset.text);
+            if (definition == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize the item definition payload.");
+            }
+
+            definition.ApplyDefaults();
+            return definition;
+        }
+    }
+
+    [Serializable]
+    public sealed class MapDefinitionDto
+    {
+        public SerializableVector2Int size = new SerializableVector2Int(1, 1);
+        public float tileSpacing = 1f;
+        public float minElevation = 0f;
+        public float maxElevation = 1f;
+        public MapTileDefinitionDto[] tiles = Array.Empty<MapTileDefinitionDto>();
+
+        public void ApplyDefaults()
+        {
+            tiles ??= Array.Empty<MapTileDefinitionDto>();
+            foreach (var tile in tiles)
+            {
+                tile?.ApplyDefaults();
+            }
+        }
+    }
+
+    [Serializable]
+    public sealed class MapTileDefinitionDto
+    {
+        public SerializableVector2Int coordinates = new SerializableVector2Int();
+        public float elevation = 0f;
+        public float traversalCost = 1f;
+
+        public void ApplyDefaults()
+        {
+            traversalCost = Mathf.Max(0f, traversalCost);
+        }
+    }
+
+    [Serializable]
+    public sealed class PawnDefinitionsDto
+    {
+        public float defaultSpeed = 2f;
+        public float defaultHeightOffset = 0.75f;
+        public PawnDefinitionDto[] pawns = Array.Empty<PawnDefinitionDto>();
+
+        public void ApplyDefaults()
+        {
+            pawns ??= Array.Empty<PawnDefinitionDto>();
+            foreach (var pawn in pawns)
+            {
+                pawn?.ApplyDefaults();
+            }
+
+            defaultSpeed = Mathf.Max(0.01f, defaultSpeed);
+        }
+    }
+
+    [Serializable]
+    public sealed class PawnDefinitionDto
+    {
+        public int id = -1;
+        public string name;
+        public string color = "#FFFFFFFF";
+        public SerializableVector2Int spawnTile = new SerializableVector2Int();
+        public float speed = -1f;
+        public float heightOffset = -1f;
+
+        public void ApplyDefaults()
+        {
+            if (string.IsNullOrWhiteSpace(color))
+            {
+                color = "#FFFFFFFF";
+            }
+        }
+    }
+
+    [Serializable]
+    public sealed class ItemDefinitionsDto
+    {
+        public ItemDefinitionDto[] items = Array.Empty<ItemDefinitionDto>();
+
+        public static ItemDefinitionsDto Empty { get; } = new ItemDefinitionsDto
+        {
+            items = Array.Empty<ItemDefinitionDto>()
+        };
+
+        public void ApplyDefaults()
+        {
+            items ??= Array.Empty<ItemDefinitionDto>();
+            foreach (var item in items)
+            {
+                item?.ApplyDefaults();
+            }
+        }
+    }
+
+    [Serializable]
+    public sealed class ItemDefinitionDto
+    {
+        public string id;
+        public string name;
+        public SerializableVector2Int tile = new SerializableVector2Int();
+
+        public void ApplyDefaults()
+        {
+            // No-op, placeholder for future validation hooks.
+        }
+    }
+
+    [Serializable]
+    public struct SerializableVector2Int
+    {
+        public int x;
+        public int y;
+
+        public SerializableVector2Int(int x, int y)
+        {
+            this.x = x;
+            this.y = y;
+        }
+
+        public Vector2Int ToVector2Int() => new Vector2Int(x, y);
+    }
+}

--- a/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
+++ b/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
@@ -124,6 +124,28 @@ namespace DataDrivenGoap
     }
 
     /// <summary>
+    /// Immutable description of an item defined in the map.
+    /// </summary>
+    public sealed class GoapItem
+    {
+        public GoapItem(string id, string name, Vector2Int tile, Vector3 worldPosition)
+        {
+            Id = string.IsNullOrEmpty(id) ? name ?? string.Empty : id;
+            Name = string.IsNullOrEmpty(name) ? Id : name;
+            Tile = tile;
+            WorldPosition = worldPosition;
+        }
+
+        public string Id { get; }
+
+        public string Name { get; }
+
+        public Vector2Int Tile { get; }
+
+        public Vector3 WorldPosition { get; }
+    }
+
+    /// <summary>
     /// Immutable snapshot of a pawn's state that can be consumed by presentation code without mutating the simulation.
     /// </summary>
     public readonly struct PawnSnapshot
@@ -156,17 +178,166 @@ namespace DataDrivenGoap
     /// </summary>
     public static class SimulationFactory
     {
-        public static Simulation Create(SimulationConfig config)
+        public static Simulation Create(
+            MapDefinitionDto mapDefinition,
+            PawnDefinitionsDto pawnDefinitions,
+            ItemDefinitionsDto itemDefinitions,
+            int randomSeed)
         {
-            if (config == null)
+            if (mapDefinition == null)
             {
-                throw new ArgumentNullException(nameof(config));
+                throw new ArgumentNullException(nameof(mapDefinition));
             }
 
+            if (pawnDefinitions == null)
+            {
+                throw new ArgumentNullException(nameof(pawnDefinitions));
+            }
+
+            mapDefinition.ApplyDefaults();
+            pawnDefinitions.ApplyDefaults();
+            itemDefinitions ??= ItemDefinitionsDto.Empty;
+            itemDefinitions.ApplyDefaults();
+
+            var mapSize = mapDefinition.size.ToVector2Int();
+            if (mapSize.x <= 0 || mapSize.y <= 0)
+            {
+                throw new ArgumentException("The map definition must specify a positive size.", nameof(mapDefinition));
+            }
+
+            var tileSpacing = Mathf.Max(0.01f, mapDefinition.tileSpacing);
+            var minElevation = Mathf.Min(mapDefinition.minElevation, mapDefinition.maxElevation);
+            var maxElevation = Mathf.Max(mapDefinition.minElevation, mapDefinition.maxElevation);
+            var pawnCount = pawnDefinitions.pawns.Length;
+            var defaultSpeed = Mathf.Max(0.01f, pawnDefinitions.defaultSpeed);
+            var defaultHeightOffset = pawnDefinitions.defaultHeightOffset;
+
+            var config = new SimulationConfig(
+                mapSize,
+                pawnCount,
+                tileSpacing,
+                new Vector2(minElevation, maxElevation),
+                defaultSpeed,
+                defaultHeightOffset,
+                randomSeed);
+
             var random = new System.Random(config.RandomSeed);
-            var map = MapGenerator.Generate(config, random);
-            var pawns = PawnFactory.Create(map, config, random);
-            return new Simulation(config, map, pawns, random);
+            var map = BuildMap(config, mapDefinition);
+            var pawns = BuildPawns(map, config, pawnDefinitions);
+            var items = BuildItems(map, itemDefinitions);
+            return new Simulation(config, map, pawns, items, random);
+        }
+
+        private static GoapMap BuildMap(SimulationConfig config, MapDefinitionDto mapDefinition)
+        {
+            var tiles = new List<MapTile>(config.MapSize.x * config.MapSize.y);
+            var halfWidth = (config.MapSize.x - 1) * 0.5f;
+            var halfHeight = (config.MapSize.y - 1) * 0.5f;
+            var minElevation = config.ElevationRange.x;
+            var maxElevation = config.ElevationRange.y;
+            var elevationRange = Mathf.Approximately(minElevation, maxElevation)
+                ? 0f
+                : maxElevation - minElevation;
+
+            var definedTiles = new HashSet<Vector2Int>();
+            foreach (var tileDefinition in mapDefinition.tiles)
+            {
+                if (tileDefinition == null)
+                {
+                    continue;
+                }
+
+                var coordinates = tileDefinition.coordinates.ToVector2Int();
+                var elevation = tileDefinition.elevation;
+                var traversalCost = Mathf.Max(0f, tileDefinition.traversalCost);
+                var normalizedElevation = elevationRange <= Mathf.Epsilon
+                    ? 0f
+                    : Mathf.Clamp01((elevation - minElevation) / elevationRange);
+                var worldCenter = new Vector3(
+                    (coordinates.x - halfWidth) * config.TileSpacing,
+                    0f,
+                    (coordinates.y - halfHeight) * config.TileSpacing);
+
+                tiles.Add(new MapTile(coordinates, elevation, normalizedElevation, traversalCost, worldCenter));
+                definedTiles.Add(coordinates);
+            }
+
+            for (var y = 0; y < config.MapSize.y; y++)
+            {
+                for (var x = 0; x < config.MapSize.x; x++)
+                {
+                    var coordinates = new Vector2Int(x, y);
+                    if (definedTiles.Contains(coordinates))
+                    {
+                        continue;
+                    }
+
+                    var worldCenter = new Vector3(
+                        (coordinates.x - halfWidth) * config.TileSpacing,
+                        0f,
+                        (coordinates.y - halfHeight) * config.TileSpacing);
+                    tiles.Add(new MapTile(coordinates, minElevation, 0f, 1f, worldCenter));
+                }
+            }
+
+            return new GoapMap(config.MapSize, tiles);
+        }
+
+        private static List<PawnInternal> BuildPawns(GoapMap map, SimulationConfig config, PawnDefinitionsDto pawnDefinitions)
+        {
+            var pawns = new List<PawnInternal>(pawnDefinitions.pawns.Length);
+            for (var i = 0; i < pawnDefinitions.pawns.Length; i++)
+            {
+                var definition = pawnDefinitions.pawns[i];
+                if (definition == null)
+                {
+                    continue;
+                }
+
+                var id = definition.id >= 0 ? definition.id : i;
+                var name = string.IsNullOrWhiteSpace(definition.name) ? $"Pawn {i + 1}" : definition.name;
+                var color = ParseColor(definition.color, i);
+                var speed = definition.speed > 0f ? definition.speed : config.PawnSpeed;
+                var heightOffset = definition.heightOffset >= 0f ? definition.heightOffset : config.PawnHeightOffset;
+                var spawnTile = definition.spawnTile.ToVector2Int();
+
+                var pawn = new PawnInternal(id, name, color, speed, heightOffset);
+                var tile = map.GetTile(spawnTile);
+                pawn.TeleportTo(tile);
+                pawn.TargetTile = spawnTile;
+                pawns.Add(pawn);
+            }
+
+            return pawns;
+        }
+
+        private static List<GoapItem> BuildItems(GoapMap map, ItemDefinitionsDto itemDefinitions)
+        {
+            var items = new List<GoapItem>(itemDefinitions.items.Length);
+            foreach (var definition in itemDefinitions.items)
+            {
+                if (definition == null)
+                {
+                    continue;
+                }
+
+                var coordinates = definition.tile.ToVector2Int();
+                var tile = map.GetTile(coordinates);
+                items.Add(new GoapItem(definition.id, definition.name, coordinates, tile.WorldSurfacePosition));
+            }
+
+            return items;
+        }
+
+        private static Color ParseColor(string value, int index)
+        {
+            if (!string.IsNullOrWhiteSpace(value) && ColorUtility.TryParseHtmlString(value, out var parsed))
+            {
+                return parsed;
+            }
+
+            var hue = Mathf.Repeat(index * 0.3125f, 1f);
+            return Color.HSVToRGB(hue, 0.8f, 1f);
         }
     }
 
@@ -178,14 +349,21 @@ namespace DataDrivenGoap
         private readonly SimulationConfig _config;
         private readonly GoapMap _map;
         private readonly List<PawnInternal> _pawns;
+        private readonly List<GoapItem> _items;
         private readonly System.Random _random;
 
-        public Simulation(SimulationConfig config, GoapMap map, List<PawnInternal> pawns, System.Random random)
+        public Simulation(
+            SimulationConfig config,
+            GoapMap map,
+            List<PawnInternal> pawns,
+            IReadOnlyList<GoapItem> items,
+            System.Random random)
         {
-            _config = config;
-            _map = map;
-            _pawns = pawns;
-            _random = random;
+            _config = config ?? throw new ArgumentNullException(nameof(config));
+            _map = map ?? throw new ArgumentNullException(nameof(map));
+            _pawns = pawns ?? throw new ArgumentNullException(nameof(pawns));
+            _items = items != null ? new List<GoapItem>(items) : new List<GoapItem>();
+            _random = random ?? throw new ArgumentNullException(nameof(random));
         }
 
         public event Action<MapTile> TileGenerated;
@@ -197,6 +375,8 @@ namespace DataDrivenGoap
         public SimulationConfig Config => _config;
 
         public GoapMap Map => _map;
+
+        public IReadOnlyList<GoapItem> Items => _items;
 
         public void Start()
         {
@@ -286,51 +466,6 @@ namespace DataDrivenGoap
 
             snapshot = default;
             return false;
-        }
-    }
-
-    internal static class MapGenerator
-    {
-        public static GoapMap Generate(SimulationConfig config, System.Random random)
-        {
-            var tiles = new List<MapTile>(config.MapSize.x * config.MapSize.y);
-            var halfWidth = (config.MapSize.x - 1) * 0.5f;
-            var halfHeight = (config.MapSize.y - 1) * 0.5f;
-
-            for (var y = 0; y < config.MapSize.y; y++)
-            {
-                for (var x = 0; x < config.MapSize.x; x++)
-                {
-                    var sample = (float)random.NextDouble();
-                    var elevation = Mathf.Lerp(config.ElevationRange.x, config.ElevationRange.y, sample);
-                    var normalized = Mathf.InverseLerp(config.ElevationRange.x, config.ElevationRange.y, elevation);
-                    var traversalCost = Mathf.Lerp(1f, 5f, (float)random.NextDouble());
-                    var worldCenter = new Vector3((x - halfWidth) * config.TileSpacing, 0f, (y - halfHeight) * config.TileSpacing);
-                    tiles.Add(new MapTile(new Vector2Int(x, y), elevation, normalized, traversalCost, worldCenter));
-                }
-            }
-
-            return new GoapMap(config.MapSize, tiles);
-        }
-    }
-
-    internal static class PawnFactory
-    {
-        public static List<PawnInternal> Create(GoapMap map, SimulationConfig config, System.Random random)
-        {
-            var pawns = new List<PawnInternal>(config.PawnCount);
-            for (var i = 0; i < config.PawnCount; i++)
-            {
-                var spawnCoordinates = new Vector2Int(random.Next(0, map.Size.x), random.Next(0, map.Size.y));
-                var color = Color.HSVToRGB((float)random.NextDouble(), 0.8f, 1f);
-                var pawn = new PawnInternal(i, $"Pawn {i + 1}", color, config.PawnSpeed, config.PawnHeightOffset);
-                var spawnTile = map.GetTile(spawnCoordinates);
-                pawn.TeleportTo(spawnTile);
-                pawn.TargetTile = spawnCoordinates;
-                pawns.Add(pawn);
-            }
-
-            return pawns;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a JSON loader that deserializes map, pawn, and item definitions from TextAssets
- build GOAP maps, pawns, and items from the parsed definitions when constructing the simulation
- bootstrap the simulation from the serialized JSON assets instead of hard-coded configuration

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df40a4978083228fbbd5fb3d0603c9