### PR TITLE
Remove redundant simulation reinitialization

### DIFF
--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -108,8 +108,6 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
             return;
         }
 
-        _config = new SimulationConfig(mapSize, pawnCount, tileSpacing, elevationRange, pawnSpeed, pawnHeightOffset, randomSeed);
-        _simulation = SimulationFactory.Create(_config);
         BuildItemSpriteLookup();
         _simulation.TileGenerated += HandleTileGenerated;
         _simulation.PawnSpawned += HandlePawnSpawned;


### PR DESCRIPTION
## Summary
- remove the redundant SimulationFactory.Create invocation in GoapSimulationBootstrapper
- keep initialization logic working with the existing simulation configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df462307f88322b2f57e2da1ac3f96