### PR TITLE
Fix GOAP bootstrapper item count log

### DIFF
--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -120,7 +120,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
         SimulationInitialized?.Invoke(_simulation);
 
         Debug.Log(
-            $"GOAP simulation started with world {_config.MapSize.x}x{_config.MapSize.y}, {_config.PawnCount} pawns, {_simulation.Items.Count} items, tile spacing {_config.TileSpacing:F2}, elevation range {_config.ElevationRange.x:F2}-{_config.ElevationRange.y:F2}, pawn speed {_config.PawnSpeed:F2}, height offset {_config.PawnHeightOffset:F2} (seed {_config.RandomSeed}).");
+            $"GOAP simulation started with world {_config.MapSize.x}x{_config.MapSize.y}, {_config.PawnCount} pawns, {_itemSnapshots.Count} items, tile spacing {_config.TileSpacing:F2}, elevation range {_config.ElevationRange.x:F2}-{_config.ElevationRange.y:F2}, pawn speed {_config.PawnSpeed:F2}, height offset {_config.PawnHeightOffset:F2} (seed {_config.RandomSeed}).");
 
         ConfigureCamera();
     }


### PR DESCRIPTION
## Summary
- update the GOAP bootstrapper startup log to report item counts using the snapshot dictionary

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df462ff3f8832289d4eeae390d1081