### PR TITLE
Fix world map loader parsing nested map definitions

### DIFF
--- a/Assets/Scripts/Goap/JsonUtilities.cs
+++ b/Assets/Scripts/Goap/JsonUtilities.cs
@@ -20,6 +20,16 @@ namespace DataDrivenGoap
             return (T)ConvertValue(typeof(T), data);
         }
 
+        public static T ConvertTo<T>(object data)
+        {
+            if (data == null)
+            {
+                return default;
+            }
+
+            return (T)ConvertValue(typeof(T), data);
+        }
+
         public static T Deserialize<T>(Stream stream)
         {
             if (stream == null)


### PR DESCRIPTION
## Summary
- expose a JsonUtilities helper to convert arbitrary objects into typed values
- update MapLoader to extract world map configs from nested `world.map` payloads and handle case-insensitive keys
- validate loaded map configs to ensure tile and asset definitions are present before continuing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfe77b11708322bebf2463bbe47d48