### PR TITLE
Configure GOAP bootstrapper data assets

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -447,12 +447,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47e3d8a842d94a4e9bcf836b1bcdcc0d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mapSize: {x: 12, y: 12}
-  pawnCount: 6
-  tileSpacing: 1.5
-  elevationRange: {x: 0.3, y: 1.5}
-  pawnSpeed: 2
-  pawnHeightOffset: 0.75
+  mapDefinitionAsset: {fileID: 4900000, guid: 8ec00b17c5e04c16a8f566f86a1a2358, type: 3}
+  pawnDefinitionAsset: {fileID: 4900000, guid: 3f73f64b8fbc4a3c9a1820e72ef7e250, type: 3}
+  itemDefinitionAsset: {fileID: 0}
+  mapLoaderSettings:
+    worldSettingsAsset: {fileID: 0}
+    villageDataAsset: {fileID: 0}
+    mapTexture: {fileID: 0}
   randomSeed: 1337
   tileScaleFactor: 0.9
   lowElevationColor: {r: 0.16, g: 0.42, b: 0.23, a: 1}

--- a/Assets/Scripts/Goap/map_definition.json
+++ b/Assets/Scripts/Goap/map_definition.json
@@ -1,0 +1,7 @@
+{
+  "size": {"x": 32, "y": 32},
+  "tileSpacing": 1.5,
+  "minElevation": 0.25,
+  "maxElevation": 1.75,
+  "tiles": []
+}

--- a/Assets/Scripts/Goap/map_definition.json.meta
+++ b/Assets/Scripts/Goap/map_definition.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8ec00b17c5e04c16a8f566f86a1a2358
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Goap/pawn_definitions.json
+++ b/Assets/Scripts/Goap/pawn_definitions.json
@@ -1,0 +1,14 @@
+{
+  "defaultSpeed": 2.25,
+  "defaultHeightOffset": 0.75,
+  "pawns": [
+    {"id": 0, "name": "Iris Ingram", "color": "#FF9A3BFF", "spawnTile": {"x": 5, "y": 5}, "speed": -1, "heightOffset": -1},
+    {"id": 1, "name": "Quentin Frost", "color": "#4FB0FFFF", "spawnTile": {"x": 10, "y": 6}, "speed": -1, "heightOffset": -1},
+    {"id": 2, "name": "Ulric Clarke", "color": "#A05CFFFF", "spawnTile": {"x": 8, "y": 9}, "speed": -1, "heightOffset": -1},
+    {"id": 3, "name": "Miles Lowell", "color": "#FF4F6AFF", "spawnTile": {"x": 15, "y": 12}, "speed": -1, "heightOffset": -1},
+    {"id": 4, "name": "Charles Yardley", "color": "#4CE58FFF", "spawnTile": {"x": 12, "y": 18}, "speed": -1, "heightOffset": -1},
+    {"id": 5, "name": "Yara North", "color": "#FFD64BFF", "spawnTile": {"x": 20, "y": 20}, "speed": -1, "heightOffset": -1},
+    {"id": 6, "name": "Thalia Grafton", "color": "#7F5CFFFF", "spawnTile": {"x": 24, "y": 10}, "speed": -1, "heightOffset": -1},
+    {"id": 7, "name": "Vera Davies", "color": "#FF8BCBFF", "spawnTile": {"x": 6, "y": 22}, "speed": -1, "heightOffset": -1}
+  ]
+}

--- a/Assets/Scripts/Goap/pawn_definitions.json.meta
+++ b/Assets/Scripts/Goap/pawn_definitions.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3f73f64b8fbc4a3c9a1820e72ef7e250
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add standalone map and pawn definition JSON assets for the GOAP simulation
- wire the GoapSimulationScene bootstrapper to use the new data-driven assets instead of hard-coded defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfea1f7b808322a6df4ef8e42f5cae