### PR TITLE
Fail fast on simulation initialization errors

### DIFF
--- a/Assets/Scripts/Goap/GoapSimulationSceneModel.cs
+++ b/Assets/Scripts/Goap/GoapSimulationSceneModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using DataDrivenGoap.Unity;
 using UnityEngine;
@@ -96,14 +97,14 @@ public sealed class GoapSimulationSceneModel : MonoBehaviour
 
     private void HandleSimulationInitialized(UnitySimulation simulation)
     {
-        if (simulation == null)
-        {
-            return;
-        }
-
         if (Simulation != null)
         {
             UnsubscribeFromSimulation(Simulation);
+        }
+
+        if (simulation == null)
+        {
+            throw new ArgumentNullException(nameof(simulation));
         }
 
         Simulation = simulation;


### PR DESCRIPTION
## Summary
- remove the blanket try/catch around simulation creation so initialization errors surface immediately
- rely on exceptions during Start and clean up partially-initialized state via try/finally
- tighten scene model initialization to reject null simulation payloads

## Testing
- not run (Unity environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0257436bc8322ab8e1dfe4246b1ac