### PR TITLE
Fix GOAP bootstrap map loading and update generator usage

### DIFF
--- a/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
+++ b/Assets/Scripts/Goap/DataDrivenGoapRuntime.cs
@@ -286,7 +286,7 @@ namespace DataDrivenGoap.Unity
 
             var random = new System.Random(initialConfig.RandomSeed);
             var content = GoapContentLoader.Load();
-            var map = MapGenerator.Generate(mapDefinition, initialConfig, random);
+            var map = MapGenerator.Generate(mapDefinition, initialConfig);
             var pawns = PawnFactory.Create(map, initialConfig, pawnDefinitions, random);
             var config = pawns.Count == initialConfig.PawnCount
                 ? initialConfig

--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -118,18 +118,8 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
 
     private bool TryLoadMapDefinition(out MapDefinitionDto mapDefinition)
     {
-        try
-        {
-            mapDefinition = LoadMapDefinition();
-            return true;
-        }
-        catch (Exception ex)
-        {
-            mapDefinition = null;
-            Debug.LogError($"Failed to load GOAP map definition: {ex.Message}", this);
-            Debug.LogException(ex, this);
-            throw;
-        }
+        mapDefinition = LoadMapDefinition();
+        return true;
     }
 
     private void OnValidate()

--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -116,6 +116,22 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
         }
     }
 
+    private bool TryLoadMapDefinition(out MapDefinitionDto mapDefinition)
+    {
+        try
+        {
+            mapDefinition = LoadMapDefinition();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            mapDefinition = null;
+            Debug.LogError($"Failed to load GOAP map definition: {ex.Message}", this);
+            Debug.LogException(ex, this);
+            throw;
+        }
+    }
+
     private void OnValidate()
     {
         if (!EditorApplication.isPlaying && mapLoaderSettings != null && mapLoaderSettings.TryAssignEditorDefaults())


### PR DESCRIPTION
## Summary
- restore the GOAP bootstrapper's ability to load map definitions with explicit logging context
- update the simulation factory to call the current MapGenerator signature

## Testing
- not run (Unity environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e027ae2e988322aa9c9f5fb6c1b13b