### PR TITLE
Use package map loader when placeholder asset is assigned

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -447,13 +447,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47e3d8a842d94a4e9bcf836b1bcdcc0d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  mapDefinitionAsset: {fileID: 4900000, guid: 8ec00b17c5e04c16a8f566f86a1a2358, type: 3}
+  mapDefinitionAsset: {fileID: 0}
   pawnDefinitionAsset: {fileID: 4900000, guid: 3f73f64b8fbc4a3c9a1820e72ef7e250, type: 3}
   itemDefinitionAsset: {fileID: 0}
   mapLoaderSettings:
-    worldSettingsAsset: {fileID: 0}
-    villageDataAsset: {fileID: 0}
-    mapTexture: {fileID: 0}
+    worldSettingsAsset: {fileID: 4900000, guid: 278b5f123d332134eaa3748ace326f4a, type: 3}
+    villageDataAsset: {fileID: 4900000, guid: 785792aedc2fade4991478d9b65842b8, type: 3}
+    mapTexture: {fileID: 2800000, guid: 7107b5145f8fc794680863ef3f1a9d0e, type: 3}
   randomSeed: 1337
   tileScaleFactor: 0.9
   lowElevationColor: {r: 0.16, g: 0.42, b: 0.23, a: 1}

--- a/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/Goap/GoapSimulationBootstrapper.cs
@@ -192,8 +192,13 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
                 var definition = LoadMapDefinitionAsset(mapDefinitionAsset);
                 if (definition.tiles == null || definition.tiles.Length == 0)
                 {
+                    if (mapLoaderSettings != null && mapLoaderSettings.IsConfigured)
+                    {
+                        return LoadMapDefinitionFromMapLoader(inlineVillage);
+                    }
+
                     throw new InvalidDataException(
-                        $"Map definition asset '{mapDefinitionAsset.name}' does not define any tiles.");
+                        $"Map definition asset '{mapDefinitionAsset.name}' does not define any tiles, and no map loader configuration is available.");
                 }
 
                 return definition;


### PR DESCRIPTION
## Summary
- detect placeholder map definition assets and route loading through the package-driven map loader when it is configured
- clear the obsolete inline map definition reference in the GOAP simulation scene and hook up the packaged DataDrivenGoap assets for loading

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e02f7ecd588322be0d88ea2b6df02b