### PR TITLE
Fix schedule hour parsing to accept HH:MM values

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -924,7 +924,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
             return 0.0;
         }
 
-        if (TimeSpan.TryParseExact(text.Trim(), new[] { "hh:mm", "hh:mm", "HH:mm", "HH:mm" }, CultureInfo.InvariantCulture, out var span))
+        if (TimeSpan.TryParseExact(text.Trim(), new[] { @"h\:mm", @"hh\:mm" }, CultureInfo.InvariantCulture, out var span))
         {
             return Math.Clamp(span.TotalHours, 0.0, 24.0);
         }


### PR DESCRIPTION
## Summary
- correct the GoapSimulationBootstrapper time parsing to use TimeSpan formats that accept HH:MM schedule values

## Testing
- dotnet build Game.sln *(fails: `dotnet` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0545f61388322919f316f361da0f4