### PR TITLE
Add animal pawn sprites to dataset manifest

### DIFF
--- a/Packages/DataDrivenGoap/Runtime/Data/sprites_manifest.json
+++ b/Packages/DataDrivenGoap/Runtime/Data/sprites_manifest.json
@@ -358,5 +358,55 @@
       "east": "sprites/pawn/P_0036_Rosa_Rowe_east.png",
       "west": "sprites/pawn/P_0036_Rosa_Rowe_west.png"
     }
+  },
+  "P-0100": {
+    "name": "Miso",
+    "role": "PetDog",
+    "sprites": {
+      "north": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "south": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "east": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "west": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png"
+    }
+  },
+  "P-0101": {
+    "name": "Juniper",
+    "role": "PetCat",
+    "sprites": {
+      "north": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "south": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "east": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "west": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png"
+    }
+  },
+  "P-0102": {
+    "name": "Betsy",
+    "role": "Cow",
+    "sprites": {
+      "north": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "south": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "east": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png",
+      "west": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0102.png"
+    }
+  },
+  "P-0103": {
+    "name": "Cloud",
+    "role": "Sheep",
+    "sprites": {
+      "north": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0103.png",
+      "south": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0103.png",
+      "east": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0103.png",
+      "west": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0103.png"
+    }
+  },
+  "P-0104": {
+    "name": "Nugget",
+    "role": "Chicken",
+    "sprites": {
+      "north": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0104.png",
+      "south": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0104.png",
+      "east": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0104.png",
+      "west": "../Packages/DataDrivenGoap/Runtime/Sprites/pawn/P-0104.png"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add sprite manifest entries for animal pawns P-0100 through P-0104
- point each entry at the packaged animal textures so the simulation can load them

## Testing
- not run (Unity editor)

------
https://chatgpt.com/codex/tasks/task_e_68e0695ea5e483228491a12fff6b7ce0