### PR TITLE
Fix observer camera alignment with pawn visuals

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -246,9 +246,15 @@ public sealed class GoapSimulationView : MonoBehaviour
             throw new InvalidOperationException($"World snapshot no longer contains the selected pawn '{selectedId.Value}'.");
         }
 
+        if (!_pawnVisuals.TryGetValue(selectedId, out var visual))
+        {
+            throw new InvalidOperationException($"Visual representation for selected pawn '{selectedId.Value}' is missing.");
+        }
+
         var cameraTransform = observerCamera.transform;
         var currentZ = cameraTransform.position.z;
-        var target = new Vector3(thing.Position.X + 0.5f, thing.Position.Y + 0.5f, currentZ);
+        var pawnWorldPosition = visual.Root.position;
+        var target = new Vector3(pawnWorldPosition.x, pawnWorldPosition.y, currentZ);
         cameraTransform.position = target;
     }
 


### PR DESCRIPTION
## Summary
- update the observer camera follow logic to use the pawn visual's world position
- add validation to ensure the selected pawn still has a visual when updating the camera

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e06bfa711883228bf9bea2abdb84e2