### PR TITLE
Ensure observer camera configuration is enforced

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -119,6 +119,11 @@ public sealed class GoapSimulationView : MonoBehaviour
         _datasetRoot = args.DatasetRoot ?? throw new InvalidOperationException("Bootstrapper emitted a null dataset root path.");
         _clock = args.Clock ?? throw new InvalidOperationException("Bootstrapper emitted a null world clock instance.");
         _selectedPawnId = ParseSelectedPawnId(args.CameraPawnId);
+        if (_selectedPawnId == null)
+        {
+            throw new InvalidOperationException(
+                "Demo configuration must define observer.cameraPawn so the observer camera can track a pawn.");
+        }
 
         EnsurePawnContainer();
         LoadSpriteManifest(Path.Combine(_datasetRoot, "sprites_manifest.json"));
@@ -246,9 +251,15 @@ public sealed class GoapSimulationView : MonoBehaviour
             throw new InvalidOperationException($"World snapshot no longer contains the selected pawn '{selectedId.Value}'.");
         }
 
+        if (!_pawnVisuals.TryGetValue(selectedId, out var visual))
+        {
+            throw new InvalidOperationException($"Visual representation for selected pawn '{selectedId.Value}' is missing.");
+        }
+
         var cameraTransform = observerCamera.transform;
         var currentZ = cameraTransform.position.z;
-        var target = new Vector3(thing.Position.X + 0.5f, thing.Position.Y + 0.5f, currentZ);
+        var pawnWorldPosition = visual.Root.position;
+        var target = new Vector3(pawnWorldPosition.x, pawnWorldPosition.y, currentZ);
         cameraTransform.position = target;
     }
 

--- a/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
+++ b/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
@@ -4330,6 +4330,10 @@
     },
     "allowAiFallback": false
   },
+  "observer": {
+    "cameraPawn": "P-0005",
+    "showOnlySelectedPawn": false
+  },
   "simulation": {
     "durationGameDays": 5.0,
     "actorHostSeed": 8675309,


### PR DESCRIPTION
## Summary
- add an observer.cameraPawn entry to the demo settings so the observer has a default target
- require GoapSimulationView to receive a configured camera pawn before building visuals, preventing a silent camera idle state

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e06bfa711883228bf9bea2abdb84e2