### PR TITLE
Fix clock label rendering guards

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -377,14 +377,17 @@ public sealed class GoapSimulationView : MonoBehaviour
     {
         bool hasClock = !string.IsNullOrEmpty(_clockLabel);
         bool hasPawnUpdate = !string.IsNullOrEmpty(_pawnUpdateLabel);
-        if (!hasClock && !hasPawnUpdate)
-        RenderClockLabel();
+
+        if (hasClock || hasPawnUpdate)
+        {
+            RenderClockLabel(hasClock, hasPawnUpdate);
+        }
         RenderSelectedPawnPanel();
     }
 
-    private void RenderClockLabel()
+    private void RenderClockLabel(bool hasClock, bool hasPawnUpdate)
     {
-        if (string.IsNullOrEmpty(_clockLabel))
+        if (!hasClock && !hasPawnUpdate)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- guard the clock and pawn status labels before rendering them in the GUI
- pass availability flags into the clock label renderer to remove undefined variable usage

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e077ecdb6c8322928c65737280b390