### PR TITLE
Refine actor shutdown sequence for GOAP simulation

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -213,7 +213,18 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
                 throw new InvalidOperationException($"Actor host list contains a null reference during shutdown (index {i}).");
             }
 
-            actor.Stop();
+            actor.RequestStop();
+        }
+
+        for (var i = 0; i < _actorHosts.Count; i++)
+        {
+            var actor = _actorHosts[i];
+            if (actor == null)
+            {
+                throw new InvalidOperationException($"Actor host list contains a null reference during shutdown (index {i}).");
+            }
+
+            actor.FinishStop();
         }
 
         if (_needScheduler != null)

--- a/Packages/DataDrivenGoap/Runtime/Execution.ExecutorsAndActorHost.cs
+++ b/Packages/DataDrivenGoap/Runtime/Execution.ExecutorsAndActorHost.cs
@@ -171,9 +171,13 @@ namespace DataDrivenGoap.Execution
         public ActorHostDiagnostics Diagnostics => _diagnostics;
 
         public void Start() { _thread.Start(); }
-        public void Stop()
+        public void RequestStop()
         {
             _stop = true;
+        }
+
+        public void FinishStop()
+        {
             _thread.Join();
             if (!string.IsNullOrEmpty(_currentGoalId))
             {
@@ -186,6 +190,12 @@ namespace DataDrivenGoap.Execution
             _log.Dispose();
             _worldLogger?.LogActorLifecycle(_self, "stop");
             UpdatePlanStatus(string.Empty, "<stopped>", Array.Empty<string>(), string.Empty, "stopped");
+        }
+
+        public void Stop()
+        {
+            RequestStop();
+            FinishStop();
         }
 
         private void RunLoop()


### PR DESCRIPTION
## Summary
- split `ActorHost.Stop` into `RequestStop`/`FinishStop` phases so threads are signaled before joining
- update the simulation bootstrapper to request all actor stops before waiting on them and stopping the need scheduler

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e08d559c508322aa2bd3c3e272283d