### PR TITLE
Disable per-actor pawn logging by default

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -665,7 +665,8 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
                 _foragingSystem,
                 _skillSystem,
                 _questSystem,
-                _worldLogger);
+                _worldLogger,
+                enablePerActorLogging: false);
             _actorHosts.Add(host);
             var diagnostics = host.Diagnostics ?? throw new InvalidOperationException($"Actor host '{entry.Id.Value}' did not expose diagnostics.");
             if (_actorDiagnostics.ContainsKey(entry.Id))


### PR DESCRIPTION
## Summary
- add an enable flag to ActorHost and PerActorLogger so hosts can disable per-actor file logging without null checks
- guard all PerActorLogger public entry points when logging is disabled to avoid creating pawn log files
- pass the disabled flag from GoapSimulationBootstrapper so simulation hosts default to no per-actor logs

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e0930d6e288322a745dd675c47ccee