### PR TITLE
Add configuration flag to disable world logging

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -405,8 +405,10 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
         ConfigureScheduleDefinitions();
 
         string logRoot = Path.Combine(Application.persistentDataPath, "goap-logs");
+        bool worldLoggingEnabled = _demoConfig?.simulation?.worldLoggingEnabled ?? true;
         Directory.CreateDirectory(logRoot);
-        _worldLogger = new WorldLogger(Path.Combine(logRoot, "world.log.txt"));
+
+        _worldLogger = new WorldLogger(Path.Combine(logRoot, "world.log.txt"), worldLoggingEnabled);
 
         _executors = new ExecutorRegistry();
         _planner = new JsonDrivenPlanner(

--- a/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
+++ b/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
@@ -672,6 +672,7 @@ namespace DataDrivenGoap.Config
         public double durationGameDays { get; set; }
         public int actorHostSeed { get; set; }
         public double priorityJitter { get; set; }
+        public bool? worldLoggingEnabled { get; set; }
     }
 
     public sealed class TimeConfig

--- a/Packages/DataDrivenGoap/Runtime/Execution.WorldLogger.cs
+++ b/Packages/DataDrivenGoap/Runtime/Execution.WorldLogger.cs
@@ -11,9 +11,18 @@ namespace DataDrivenGoap.Execution
 
         private readonly object _gate = new object();
         private readonly RollingLogWriter _writer;
+        private readonly bool _enabled;
 
-        public WorldLogger(string filePath)
+        public WorldLogger(string filePath, bool enabled = true)
         {
+            _enabled = enabled;
+
+            if (!_enabled)
+            {
+                _writer = null;
+                return;
+            }
+
             if (string.IsNullOrWhiteSpace(filePath))
                 throw new ArgumentException("World log file path must be provided", nameof(filePath));
 
@@ -239,6 +248,11 @@ namespace DataDrivenGoap.Execution
 
         private void Write(string category, string message)
         {
+            if (!_enabled)
+            {
+                return;
+            }
+
             lock (_gate)
             {
                 _writer.WriteLine($"{DateTime.UtcNow:HH:mm:ss.fff}|{category ?? "LOG"} {message ?? string.Empty}");
@@ -294,6 +308,11 @@ namespace DataDrivenGoap.Execution
 
         public void Dispose()
         {
+            if (!_enabled)
+            {
+                return;
+            }
+
             lock (_gate)
             {
                 _writer?.Dispose();


### PR DESCRIPTION
## Summary
- add a nullable `worldLoggingEnabled` flag to the simulation config data
- allow `WorldLogger` to be constructed in a disabled mode that skips file writes
- respect the new flag in the simulation bootstrapper so world logging can be turned off without errors

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0946409b48322a77e07cfe5d371d8