### PR TITLE
Disable world logging by default

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -406,7 +406,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
 
         string logRoot = Path.Combine(Application.persistentDataPath, "goap-logs");
         string worldLogPath = Path.Combine(logRoot, "world.log.txt");
-        bool worldLoggingEnabled = _demoConfig?.simulation?.worldLoggingEnabled ?? true;
+        bool worldLoggingEnabled = _demoConfig?.simulation?.worldLoggingEnabled ?? false;
 
         if (worldLoggingEnabled)
         {


### PR DESCRIPTION
## Summary
- default the simulation bootstrapper to disable world logging when the dataset does not specify a preference
- keep the ability to enable logging via configuration while preventing world log files from being generated by default

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e097495ff48322a4da4017c2a56e90