### PR TITLE
Add manual player pawn support

### DIFF
--- a/Assets/Scripts/PlayerPawnController.cs
+++ b/Assets/Scripts/PlayerPawnController.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Linq;
+using DataDrivenGoap.Core;
+using DataDrivenGoap.Effects;
+using DataDrivenGoap.World;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[DisallowMultipleComponent]
+public sealed class PlayerPawnController : MonoBehaviour
+{
+    [SerializeField] private GoapSimulationBootstrapper bootstrapper;
+    [SerializeField, Min(0.01f)] private float moveIntervalSeconds = 0.2f;
+
+    private IWorld _world;
+    private ThingId? _playerPawnId;
+    private float _moveCooldown;
+
+    private void Awake()
+    {
+        EnsureBootstrapperReference();
+    }
+
+    private void OnEnable()
+    {
+        EnsureBootstrapperReference();
+        bootstrapper.Bootstrapped += HandleBootstrapped;
+        if (bootstrapper.HasBootstrapped)
+        {
+            HandleBootstrapped(bootstrapper, bootstrapper.LatestBootstrap);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (bootstrapper != null)
+        {
+            bootstrapper.Bootstrapped -= HandleBootstrapped;
+        }
+
+        _world = null;
+        _playerPawnId = null;
+        _moveCooldown = 0f;
+    }
+
+    private void Update()
+    {
+        if (_world == null || !_playerPawnId.HasValue)
+        {
+            return;
+        }
+
+        if (moveIntervalSeconds <= 0f)
+        {
+            throw new InvalidOperationException("PlayerPawnController requires 'moveIntervalSeconds' to be greater than zero.");
+        }
+
+        if (_moveCooldown > 0f)
+        {
+            _moveCooldown -= Time.deltaTime;
+        }
+
+        var direction = ReadMovementInput();
+        if (direction == Vector2Int.zero)
+        {
+            return;
+        }
+
+        if (_moveCooldown > 0f)
+        {
+            return;
+        }
+
+        ExecuteMove(direction);
+    }
+
+    private void HandleBootstrapped(object sender, GoapSimulationBootstrapper.SimulationReadyEventArgs args)
+    {
+        if (args == null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        if (args.World == null)
+        {
+            throw new InvalidOperationException("Bootstrapper emitted a null world instance for the player controller.");
+        }
+
+        if (!args.PlayerPawnId.HasValue)
+        {
+            throw new InvalidOperationException("Bootstrapper did not designate a player pawn id for manual control.");
+        }
+
+        if (args.ManualPawnIds == null || !args.ManualPawnIds.Contains(args.PlayerPawnId.Value))
+        {
+            throw new InvalidOperationException($"Player pawn '{args.PlayerPawnId.Value.Value}' was not flagged for manual control in the bootstrap configuration.");
+        }
+
+        _world = args.World;
+        _playerPawnId = args.PlayerPawnId.Value;
+        _moveCooldown = 0f;
+    }
+
+    private Vector2Int ReadMovementInput()
+    {
+        var keyboard = Keyboard.current;
+        if (keyboard == null)
+        {
+            return Vector2Int.zero;
+        }
+
+        var direction = Vector2Int.zero;
+        if (keyboard.wKey.isPressed || keyboard.upArrowKey.isPressed)
+        {
+            direction += Vector2Int.up;
+        }
+
+        if (keyboard.sKey.isPressed || keyboard.downArrowKey.isPressed)
+        {
+            direction += Vector2Int.down;
+        }
+
+        if (keyboard.aKey.isPressed || keyboard.leftArrowKey.isPressed)
+        {
+            direction += Vector2Int.left;
+        }
+
+        if (keyboard.dKey.isPressed || keyboard.rightArrowKey.isPressed)
+        {
+            direction += Vector2Int.right;
+        }
+
+        if (direction.x != 0 && direction.y != 0)
+        {
+            if (Mathf.Abs(direction.x) > Mathf.Abs(direction.y))
+            {
+                direction.y = 0;
+            }
+            else
+            {
+                direction.x = 0;
+            }
+        }
+
+        return direction;
+    }
+
+    private void ExecuteMove(Vector2Int direction)
+    {
+        var snapshot = _world.Snap();
+        var playerId = _playerPawnId.Value;
+        var playerThing = snapshot.GetThing(playerId);
+        if (playerThing == null)
+        {
+            throw new InvalidOperationException($"World snapshot no longer contains the player pawn '{playerId.Value}'.");
+        }
+
+        var target = new GridPos(playerThing.Position.X + direction.x, playerThing.Position.Y + direction.y);
+        if (!snapshot.IsWalkable(target.X, target.Y))
+        {
+            return;
+        }
+
+        var batch = new EffectBatch
+        {
+            BaseVersion = snapshot.Version,
+            Reads = new[] { new ReadSetEntry(playerId, null, null) },
+            Writes = new[]
+            {
+                new WriteSetEntry(playerId, "@move.x", target.X),
+                new WriteSetEntry(playerId, "@move.y", target.Y)
+            },
+            FactDeltas = Array.Empty<FactDelta>(),
+            Spawns = Array.Empty<ThingSpawnRequest>(),
+            PlanCooldowns = Array.Empty<PlanCooldownRequest>(),
+            Despawns = Array.Empty<ThingId>(),
+            InventoryOps = Array.Empty<InventoryDelta>(),
+            CurrencyOps = Array.Empty<CurrencyDelta>(),
+            ShopTransactions = Array.Empty<ShopTransaction>(),
+            RelationshipOps = Array.Empty<RelationshipDelta>(),
+            CropOps = Array.Empty<CropOperation>(),
+            AnimalOps = Array.Empty<AnimalOperation>(),
+            MiningOps = Array.Empty<MiningOperation>(),
+            FishingOps = Array.Empty<FishingOperation>(),
+            ForagingOps = Array.Empty<ForagingOperation>(),
+            QuestOps = Array.Empty<QuestOperation>()
+        };
+
+        var result = _world.TryCommit(batch);
+        if (result == CommitResult.Conflict)
+        {
+            throw new InvalidOperationException($"Player movement commit conflicted while moving to ({target.X}, {target.Y}).");
+        }
+
+        _moveCooldown = moveIntervalSeconds;
+    }
+
+    private void EnsureBootstrapperReference()
+    {
+        if (bootstrapper == null)
+        {
+            bootstrapper = FindFirstObjectByType<GoapSimulationBootstrapper>();
+        }
+
+        if (bootstrapper == null)
+        {
+            throw new InvalidOperationException("PlayerPawnController could not locate a GoapSimulationBootstrapper in the scene.");
+        }
+    }
+}

--- a/Assets/Scripts/PlayerPawnController.cs.meta
+++ b/Assets/Scripts/PlayerPawnController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 17d4f996b1ad4cee8945ddd595fa33e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
+++ b/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
@@ -792,6 +792,23 @@ namespace DataDrivenGoap.Config
         public FileReferenceConfig quests { get; set; }
         public PersistenceConfig persistence { get; set; }
         public ObserverConfig observer { get; set; }
+        public PlayerConfig player { get; set; }
+    }
+
+    public sealed class PlayerConfig
+    {
+        public string id { get; set; }
+        public string[] tags { get; set; }
+        public PlayerSpawnConfig spawn { get; set; }
+        public InventoryConfig inventory { get; set; }
+        public double? currency { get; set; }
+        public Dictionary<string, double> attributes { get; set; }
+        public bool allowAiFallback { get; set; }
+    }
+
+    public sealed class PlayerSpawnConfig
+    {
+        public string id { get; set; }
     }
 
     public sealed class ItemDatabaseConfig
@@ -1085,6 +1102,11 @@ namespace DataDrivenGoap.Config
                 throw new InvalidDataException($"Demo config '{sourcePath}' is missing the 'persistence' section.");
             }
 
+            if (config.player is null)
+            {
+                throw new InvalidDataException($"Demo config '{sourcePath}' is missing the 'player' section.");
+            }
+
             ValidateWorldConfig(config.world, sourcePath);
             ValidateSimulationConfig(config.simulation, sourcePath);
             ValidateTimeConfig(config.time, sourcePath);
@@ -1100,6 +1122,25 @@ namespace DataDrivenGoap.Config
             ValidatePersistenceConfig(config.persistence, sourcePath);
             ValidateActorSeedConfig(config.actors, sourcePath);
             ValidateSocialConfig(config.social, sourcePath);
+            ValidatePlayerConfig(config.player, sourcePath);
+        }
+
+        private static void ValidatePlayerConfig(PlayerConfig config, string sourcePath)
+        {
+            if (string.IsNullOrWhiteSpace(config.id))
+            {
+                throw new InvalidDataException($"Demo config '{sourcePath}' is missing a non-empty 'player.id'.");
+            }
+
+            if (config.spawn is null || string.IsNullOrWhiteSpace(config.spawn.id))
+            {
+                throw new InvalidDataException($"Demo config '{sourcePath}' must specify 'player.spawn.id'.");
+            }
+
+            if (config.inventory == null)
+            {
+                throw new InvalidDataException($"Demo config '{sourcePath}' must define 'player.inventory'.");
+            }
         }
 
         private static void ValidateWorldConfig(WorldConfig config, string sourcePath)

--- a/Packages/DataDrivenGoap/Runtime/Data/village_data.json
+++ b/Packages/DataDrivenGoap/Runtime/Data/village_data.json
@@ -951,6 +951,17 @@
           "start": []
         },
         "currency": 0
+      },
+      {
+        "id": "player",
+        "name": "Player",
+        "role": "Player",
+        "home": {
+          "location": "Bakery"
+        },
+        "workplace": {
+          "location": "Bakery"
+        }
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add player configuration support in the data loader and declare the player pawn in the dataset
- update the bootstrapper and view to recognise manually controlled pawns and exclude them from GOAP hosting
- implement a PlayerPawnController that drives the player pawn via keyboard input using world commits

## Testing
- dotnet build Game.sln *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10bac676483229d6fca7dee5b0c95