### PR TITLE
Fix observer camera pawn casing mismatch

### DIFF
--- a/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
+++ b/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
@@ -4331,7 +4331,7 @@
     "allowAiFallback": false
   },
   "observer": {
-    "cameraPawn": "Player",
+    "cameraPawn": "player",
     "showOnlySelectedPawn": false
   },
   "simulation": {


### PR DESCRIPTION
## Summary
- align the configured observer camera pawn id with the actual player pawn identifier in the dataset so the bootstrap can locate diagnostics and visuals

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e144391734832287343ba84676a0ae