### PR TITLE
Add player pawn controller to GOAP simulation scene

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -498,6 +498,61 @@ MonoBehaviour:
   pawnContainer: {fileID: 0}
   mapSortingOrder: -100
   pawnSortingOrder: 0
+--- !u!1 &100040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100041}
+  - component: {fileID: 100042}
+  m_Layer: 0
+  m_Name: Player Pawn Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100041
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100040}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17d4f996b1ad4cee8945ddd595fa33e3, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bootstrapper: {fileID: 100022}
+  moveIntervalSeconds: 0.2
+  moveAction:
+    m_Asset: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    m_ActionId: 351f2ccd-1f9f-44bf-9bec-d62ac5c5f408
+    m_Reference: {fileID: 0}
+  interactAction:
+    m_Asset: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
+    m_ActionId: 852140f2-7766-474d-8707-702459ba45f3
+    m_Reference: {fileID: 0}
+  movementDeadZone: 0.4
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -506,3 +561,4 @@ SceneRoots:
   - {fileID: 100012}
   - {fileID: 100021}
   - {fileID: 100031}
+  - {fileID: 100041}


### PR DESCRIPTION
## Summary
- add a Player Pawn Controller object to the GoapSimulationScene
- wire the PlayerPawnController to the scene bootstrapper and Player Move/Interact input actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14afbe80483228eb0cde9c57050a6