### PR TITLE
Improve camera discovery for GoapSimulationView

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -1034,7 +1034,27 @@ public sealed class GoapSimulationView : MonoBehaviour
 
     private void EnsureObserverCamera()
     {
-        var resolvedCamera = observerCamera ?? Camera.main;
+        var resolvedCamera = observerCamera;
+        if (resolvedCamera == null)
+        {
+            resolvedCamera = GetComponent<Camera>();
+        }
+
+        if (resolvedCamera == null)
+        {
+            resolvedCamera = GetComponentInChildren<Camera>(true);
+        }
+
+        if (resolvedCamera == null)
+        {
+            resolvedCamera = Camera.main;
+        }
+
+        if (resolvedCamera == null)
+        {
+            resolvedCamera = FindFirstObjectByType<Camera>();
+        }
+
         if (resolvedCamera == null)
         {
             throw new InvalidOperationException("GoapSimulationView requires a Camera reference to center on the selected pawn.");


### PR DESCRIPTION
## Summary
- broaden the observer camera resolution logic to inspect local and child cameras before erroring
- retain the fail-fast behavior when no camera is discoverable

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e16294eb808322b39ac1b84cbbbc0d