### PR TITLE
Add manual plan selection controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-"# Game" 
+# Game
+
+## Manual plan selection
+
+The GOAP simulation view now exposes manual planning controls that write the
+following attributes for the player pawn:
+
+- `@manual.interact.seq`
+- `@manual.interact.x`
+- `@manual.interact.y`
+- `@manual.interact.hasTarget`
+- `@manual.interact.planStep`
+
+The dataset shipped under `Packages/DataDrivenGoap/Runtime/Data` must declare
+the corresponding manual-action attributes and facts (including
+`manual_interact_target`) so the simulation continues to fail fast if they are
+missing. Update your dataset configuration alongside code changes whenever new
+manual control channels are introduced.


### PR DESCRIPTION
## Summary
- allow GoapSimulationView to pick pawns via mouse clicks and render plan controls for manual actors
- route UI selections through a new RequestManualInteract path in PlayerPawnController to record plan step choices
- document the manual interaction attributes that must exist in the DataDrivenGoap dataset

## Testing
- dotnet build Game.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e174cebc308322928c20153a7fdaae