### PR TITLE
Align map texture indexing with bottom-left grid coordinates

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -1614,7 +1614,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
             {
                 for (int x = 0; x < width; x++)
                 {
-                    var pixel = pixels[(height - 1 - y) * width + x];
+                    var pixel = pixels[y * width + x];
                     if (!colorMap.TryGetValue(pixel, out var tileId))
                     {
                         throw new InvalidDataException($"Map tile color {pixel} at {x},{y} does not match any key entry.");

--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -1063,7 +1063,7 @@ public sealed class GoapSimulationView : MonoBehaviour
         {
             for (int x = 0; x < expectedWidth; x++)
             {
-                int pixelIndex = (expectedHeight - 1 - y) * expectedWidth + x;
+                int pixelIndex = y * expectedWidth + x;
                 var baseColor = basePixels[pixelIndex];
                 outputPixels[pixelIndex] = walkable[x, y] ? baseColor : BlendBuildingTint(baseColor);
             }


### PR DESCRIPTION
## Summary
- align walkability tile classification with bottom-left origin by reading pixels in scanline order
- update map overlay generation to use matching pixel indexing so tinting stays in sync with walkability

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68e19b6ed0188322880a3cf6dcfbae82