### PR TITLE
Restock shops before starting GOAP simulation

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -498,8 +498,32 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
             _skillSystem);
 
         BuildActorHosts(logRoot);
+        PerformInitialShopRestock();
         NotifyBootstrapped(datasetRoot);
         StartSimulation();
+    }
+
+    private void PerformInitialShopRestock()
+    {
+        if (_shopSystem == null || _clock == null)
+        {
+            return;
+        }
+
+        var bootstrapTime = _clock.Snapshot();
+        _shopSystem.Tick(bootstrapTime);
+
+        var generalStoreId = new ThingId("store_generalstore");
+        var generalStore = _shopSystem.GetShop(generalStoreId);
+        if (generalStore != null)
+        {
+            bool hasStock = generalStore.Stock.Any(entry => entry != null && entry.Quantity > 0);
+            if (!hasStock)
+            {
+                throw new InvalidOperationException(
+                    "Shop 'store_generalstore' did not report stocked inventory after the bootstrap restock tick.");
+            }
+        }
     }
 
     private void NotifyBootstrapped(string datasetRoot)


### PR DESCRIPTION
## Summary
- tick the shop system once during bootstrap so shops restock before actors begin planning
- assert the general store reports stocked inventory immediately after the bootstrap restock

## Testing
- not run (Unity environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1af719b7883228a7f7fa8246528c2