### PR TITLE
Map item icon to sprite slug

### DIFF
--- a/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
+++ b/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DataDrivenGoap.Config
 {
@@ -57,6 +58,8 @@ namespace DataDrivenGoap.Config
         public ItemEffectConfig[] effects { get; set; }
         public string[] tools { get; set; }
         public string[] gifts { get; set; }
+
+        [JsonPropertyName("icon")]
         public string spriteSlug { get; set; }
     }
 


### PR DESCRIPTION
## Summary
- deserialize item icon JSON value directly into the sprite slug field so item catalogs can resolve sprites

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1cd33eaec83228850230ddad2884f