### PR TITLE
Fix normalized path backslash replacement

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -1490,7 +1490,7 @@ public sealed class GoapSimulationView : MonoBehaviour
             trimmed = trimmed.Substring(1);
         }
 
-        var normalizedRelative = trimmed.Replace('\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+        var normalizedRelative = trimmed.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
         foreach (var root in EnumerateSpriteSearchRoots())
         {
             if (TryResolveRelativePathCaseInsensitive(root, normalizedRelative, out var resolved))


### PR DESCRIPTION
## Summary
- fix the normalized relative path routine to escape the backslash character literal correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d7680d988322ba51d7d8c0ab597e