### PR TITLE
Allow manual interact requests for distant targets

### DIFF
--- a/Assets/Scripts/PlayerPawnController.cs
+++ b/Assets/Scripts/PlayerPawnController.cs
@@ -275,13 +275,6 @@ public sealed class PlayerPawnController : MonoBehaviour
             throw new InvalidOperationException($"Manual interaction target position ({targetPos.X}, {targetPos.Y}) is outside the world bounds {snapshot.Width}x{snapshot.Height}.");
         }
 
-        var distance = GridPos.Manhattan(playerThing.Position, targetPos);
-        if (distance > 1)
-        {
-            throw new InvalidOperationException(
-                $"Manual interaction target at ({targetPos.X}, {targetPos.Y}) is not adjacent to player position ({playerThing.Position.X}, {playerThing.Position.Y}).");
-        }
-
         bool hasTarget = !string.IsNullOrWhiteSpace(targetId.Value);
         ThingView targetThing = null;
         if (hasTarget)


### PR DESCRIPTION
## Summary
- allow ExecuteManualInteract to queue manual interaction requests without requiring adjacency
- retain world bounds and target validation so distant requests still validate

## Testing
- not run (Unity Play Mode required)

------
https://chatgpt.com/codex/tasks/task_e_68e26a6ee50083229f019016b2264be5