### PR TITLE
Add Effects namespace import to GOAP bootstrapper

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -7,6 +7,7 @@ using DataDrivenGoap.Config;
 using DataDrivenGoap.Concurrency;
 using DataDrivenGoap.Core;
 using DataDrivenGoap.Execution;
+using DataDrivenGoap.Effects;
 using DataDrivenGoap.Items;
 using DataDrivenGoap.Planning;
 using DataDrivenGoap.Simulation;


### PR DESCRIPTION
## Summary
- add the DataDrivenGoap.Effects namespace import to GoapSimulationBootstrapper so effect-related types resolve

## Testing
- dotnet build Game.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e277ef714083229f494688b6147d6a