### PR TITLE
Fix Random namespace usage in GOAP bootstrapper

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -200,12 +200,12 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
 
     private sealed class ManualActorState
     {
-        public ManualActorState(Random rng)
+        public ManualActorState(System.Random rng)
         {
             Rng = rng ?? throw new ArgumentNullException(nameof(rng));
         }
 
-        public Random Rng { get; }
+        public System.Random Rng { get; }
         public Dictionary<string, DateTime> PlanCooldownUntil { get; } =
             new Dictionary<string, DateTime>(StringComparer.Ordinal);
     }
@@ -552,7 +552,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
         if (!_manualActorStates.TryGetValue(key, out var state) || state == null)
         {
             int seed = _demoConfig?.simulation?.actorHostSeed ?? 0;
-            state = new ManualActorState(new Random(seed ^ actorId.GetHashCode()));
+            state = new ManualActorState(new System.Random(seed ^ actorId.GetHashCode()));
             _manualActorStates[key] = state;
         }
 


### PR DESCRIPTION
## Summary
- update ManualActorState to store a System.Random instance explicitly
- ensure manual actor state seeding uses System.Random to avoid ambiguous references

## Testing
- `dotnet build Game.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e277f4ccb08322bec6cfd2212a8579