### PR TITLE
Handle advancing snapshot versions for manual plan execution

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -440,10 +440,15 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
                 throw new InvalidOperationException("World snapshot could not be captured for manual plan execution.");
             }
 
-            if (snapshot.Version != currentExpectedVersion)
+            if (snapshot.Version < currentExpectedVersion)
             {
                 throw new InvalidOperationException(
-                    $"Manual plan snapshot version mismatch. Expected {currentExpectedVersion}, but world reports {snapshot.Version}.");
+                    $"Manual plan snapshot version regressed. Expected at least {currentExpectedVersion}, but world reports {snapshot.Version}.");
+            }
+
+            if (snapshot.Version > currentExpectedVersion)
+            {
+                currentExpectedVersion = snapshot.Version;
             }
 
             var actorThing = snapshot.GetThing(actorId);


### PR DESCRIPTION
## Summary
- ensure manual plan execution only fails when snapshots regress and update the expected version when the world advances
- relax player pawn snapshot verification by retrying for the committed version and allowing newer snapshots after manual plan steps

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e2895d18848322a35a79c78ab38a56