### PR TITLE
Require goal identifiers for manual plan execution

### DIFF
--- a/Assets/Scripts/PlayerPawnController.cs
+++ b/Assets/Scripts/PlayerPawnController.cs
@@ -241,7 +241,8 @@ public sealed class PlayerPawnController : MonoBehaviour
         GridPos targetPos,
         int? planStepIndex = null,
         long? expectedSnapshotVersion = null,
-        string planStepActivity = null)
+        string planStepActivity = null,
+        string planGoalId = null)
     {
         if (_world == null)
         {
@@ -271,6 +272,19 @@ public sealed class PlayerPawnController : MonoBehaviour
                     "Manual plan execution requires the activity identifier associated with the selected plan option.");
             }
 
+            if (string.IsNullOrWhiteSpace(planGoalId))
+            {
+                throw new InvalidOperationException(
+                    "Manual plan execution requires the goal identifier associated with the selected plan option.");
+            }
+
+            var normalizedGoalId = planGoalId.Trim();
+            if (normalizedGoalId.Length == 0)
+            {
+                throw new InvalidOperationException(
+                    "Manual plan execution requires a non-empty goal identifier after trimming.");
+            }
+
             var expectedTarget = hasTarget ? (ThingId?)targetId : null;
             var expectedPosition = hasTarget ? (GridPos?)targetPos : null;
             updatedSnapshotVersion = bootstrapper.ExecuteManualPlanStepSequence(
@@ -279,7 +293,8 @@ public sealed class PlayerPawnController : MonoBehaviour
                 planStepActivity,
                 expectedTarget,
                 expectedPosition,
-                expectedSnapshotVersion.Value);
+                expectedSnapshotVersion.Value,
+                normalizedGoalId);
         }
 
         IWorldSnapshot snapshot = null;


### PR DESCRIPTION
## Summary
- capture each plan option's goal identifier in the simulation view and forward it when invoking manual interactions
- require manual interaction requests with plan steps to include a goal id and pass it through to the bootstrapper
- execute manual plan steps against an expected goal id, validating planner results for emptiness and mismatched goals

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2a6532ff483228ab20aa356945a72