### PR TITLE
Fix manual plan goal selection

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -2756,6 +2756,13 @@ public sealed class GoapSimulationView : MonoBehaviour
                 $"Plan option '{option.Label}' is missing the associated goal identifier required for manual execution.");
         }
 
+        var participationGoalId = participation.GoalId?.Trim();
+        if (string.IsNullOrEmpty(participationGoalId))
+        {
+            throw new InvalidOperationException(
+                $"Participation entry '{participation}' is missing the associated goal identifier required for manual execution.");
+        }
+
         EnsurePlayerPawnController();
 
         if (_selectedPawnId == null)
@@ -2777,7 +2784,7 @@ public sealed class GoapSimulationView : MonoBehaviour
             option.StepIndex,
             _selectedPawnPlanSnapshotVersion,
             option.ActivityId,
-            option.GoalId);
+            participationGoalId);
         _selectedPlanOptionIndex = participationIndex;
         _selectedPlanOptionLabel = participationIndex < _selectedThingPlanLines.Length
             ? _selectedThingPlanLines[participationIndex]


### PR DESCRIPTION
## Summary
- ensure manual plan requests use the goal associated with the clicked participation entry
- add guard that throws when the participation entry is missing a usable goal identifier

## Testing
- not run (editor environment only)

------
https://chatgpt.com/codex/tasks/task_e_68e2c8454a448322b8922d9cde49b012