### PR TITLE
Throttle GOAP actor threads to 2 Hz

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -2335,6 +2335,7 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
                 _demoConfig.simulation.actorHostSeed,
                 logRoot,
                 _demoConfig.simulation.priorityJitter,
+                _demoConfig.simulation.actorLoopFrequencyHz,
                 _scheduleService,
                 _inventorySystem,
                 _shopSystem,

--- a/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
+++ b/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
@@ -675,6 +675,7 @@ namespace DataDrivenGoap.Config
         public double durationGameDays { get; set; }
         public int actorHostSeed { get; set; }
         public double priorityJitter { get; set; }
+        public double actorLoopFrequencyHz { get; set; }
         public bool? worldLoggingEnabled { get; set; }
     }
 
@@ -1194,6 +1195,11 @@ namespace DataDrivenGoap.Config
             if (config.priorityJitter < 0)
             {
                 throw new InvalidDataException($"Demo config '{sourcePath}' has an invalid 'simulation.priorityJitter' value of {config.priorityJitter}. It cannot be negative.");
+            }
+
+            if (double.IsNaN(config.actorLoopFrequencyHz) || double.IsInfinity(config.actorLoopFrequencyHz) || config.actorLoopFrequencyHz <= 0.0)
+            {
+                throw new InvalidDataException($"Demo config '{sourcePath}' has an invalid 'simulation.actorLoopFrequencyHz' value of {config.actorLoopFrequencyHz}. It must be a finite number greater than zero.");
             }
         }
 

--- a/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
+++ b/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
@@ -4341,6 +4341,7 @@
     "durationGameDays": 5.0,
     "actorHostSeed": 8675309,
     "priorityJitter": 0.05,
+    "actorLoopFrequencyHz": 2.0,
     "perPawnLoggingEnabled": false
   },
   "time": {


### PR DESCRIPTION
## Summary
- add a configurable actor loop frequency to the simulation settings and dataset
- throttle each actor host thread so plan selection respects the configured 2 Hz cadence
- wire the bootstrapper to pass the frequency into the actor hosts

## Testing
- `dotnet build Game.sln` *(fails: `dotnet` CLI is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c974ec448322a5a05b06790fb4e9