### PR TITLE
Add toggle to disable automatic manual plan evaluation

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -121,6 +121,7 @@ public sealed class GoapSimulationView : MonoBehaviour
     private ThingId? _selectedPawnId;
     private readonly Dictionary<ThingId, VillagePawn> _pawnDefinitions = new Dictionary<ThingId, VillagePawn>();
     private readonly HashSet<ThingId> _manualPawnIds = new HashSet<ThingId>();
+    private bool _manualPlanAutoEvaluationEnabled = true;
     private readonly StringBuilder _selectedPawnPanelBuilder = new StringBuilder();
     private readonly List<(string Label, double? Value)> _selectedPawnNeeds = new List<(string Label, double? Value)>();
     private string[] _selectedPawnPlanSteps = Array.Empty<string>();
@@ -324,6 +325,7 @@ public sealed class GoapSimulationView : MonoBehaviour
                 _manualPawnIds.Add(manualId);
             }
         }
+        _manualPlanAutoEvaluationEnabled = args.ManualPlanAutoEvaluationEnabled;
         _datasetRoot = args.DatasetRoot ?? throw new InvalidOperationException("Bootstrapper emitted a null dataset root path.");
         _clock = args.Clock ?? throw new InvalidOperationException("Bootstrapper emitted a null world clock instance.");
         _tileClassification = args.TileClassification ?? throw new InvalidOperationException("Bootstrapper emitted a null tile classification snapshot.");
@@ -1603,6 +1605,17 @@ public sealed class GoapSimulationView : MonoBehaviour
 
         builder.AppendLine();
         builder.AppendLine(string.IsNullOrWhiteSpace(selectedPawnPanelPlanHeader) ? "Plan" : selectedPawnPanelPlanHeader);
+        bool selectedPawnManual = _manualPawnIds.Contains(selectedId);
+        if (selectedPawnManual && !_manualPlanAutoEvaluationEnabled)
+        {
+            builder.AppendLine("  Automatic plan evaluation disabled.");
+            var disabledText = builder.ToString();
+            _selectedPawnPlanStepLines = Array.Empty<string>();
+            _selectedPawnPanelTextBeforePlanSteps = disabledText;
+            _selectedPawnPanelTextAfterPlanSteps = string.Empty;
+            _selectedPawnPanelText = disabledText.TrimEnd('\r', '\n');
+            return _selectedPawnPanelText;
+        }
         bool hasPlanContent = false;
         if (!string.IsNullOrEmpty(_selectedPawnPlanState))
         {

--- a/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
+++ b/Packages/DataDrivenGoap/Runtime/Config.Loader.cs
@@ -808,6 +808,7 @@ namespace DataDrivenGoap.Config
         public double? currency { get; set; }
         public Dictionary<string, double> attributes { get; set; }
         public bool allowAiFallback { get; set; }
+        public bool? autoEvaluateManualPlans { get; set; }
     }
 
     public sealed class PlayerSpawnConfig

--- a/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
+++ b/Packages/DataDrivenGoap/Runtime/Data/demo.settings.json
@@ -4331,7 +4331,8 @@
       "fatigue": 0.1,
       "loneliness": 0.3
     },
-    "allowAiFallback": false
+    "allowAiFallback": false,
+    "autoEvaluateManualPlans": false
   },
   "observer": {
     "cameraPawn": "player",


### PR DESCRIPTION
## Summary
- add a `autoEvaluateManualPlans` player configuration knob to control manual plan auto-evaluation
- propagate the toggle through the bootstrapper and simulation view so manual pawns stop evaluating plans when disabled
- surface the setting in the demo configuration and update the player plan panel to show that automatic evaluation is disabled

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e335d8d5388322be6a34c1908d3f2a