### PR TITLE
Enable manual execution of player pawn plans

### DIFF
--- a/Assets/Scripts/GoapSimulationBootstrapper.cs
+++ b/Assets/Scripts/GoapSimulationBootstrapper.cs
@@ -423,12 +423,6 @@ public sealed class GoapSimulationBootstrapper : MonoBehaviour
 
         if (_manualPawnIds.Contains(actorId))
         {
-            if (!_manualPlanAutoEvaluationEnabled)
-            {
-                status = null;
-                return false;
-            }
-
             status = SnapshotManualPlanStatus(actorId);
             return status != null;
         }

--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -1617,18 +1617,14 @@ public sealed class GoapSimulationView : MonoBehaviour
 
         builder.AppendLine();
         builder.AppendLine(string.IsNullOrWhiteSpace(selectedPawnPanelPlanHeader) ? "Plan" : selectedPawnPanelPlanHeader);
+        bool hasPlanContent = false;
         bool selectedPawnManual = _manualPawnIds.Contains(selectedId);
         if (selectedPawnManual && !_manualPlanAutoEvaluationEnabled)
         {
             builder.AppendLine("  Automatic plan evaluation disabled.");
-            var disabledText = builder.ToString();
-            _selectedPawnPlanStepLines = Array.Empty<string>();
-            _selectedPawnPanelTextBeforePlanSteps = disabledText;
-            _selectedPawnPanelTextAfterPlanSteps = string.Empty;
-            _selectedPawnPanelText = disabledText.TrimEnd('\r', '\n');
-            return _selectedPawnPanelText;
+            builder.AppendLine("  Select a plan step to command this pawn manually.");
+            hasPlanContent = true;
         }
-        bool hasPlanContent = false;
         if (!string.IsNullOrEmpty(_selectedPawnPlanState))
         {
             builder.Append("  State: ").Append(_selectedPawnPlanState).AppendLine();


### PR DESCRIPTION
## Summary
- allow manual actors to expose their current plan even when automatic evaluation is disabled so the manual action list can populate
- keep the pawn detail panel available in manual mode and show guidance instead of blocking the plan section

## Testing
- not run (explanation)

------
https://chatgpt.com/codex/tasks/task_e_68e33aad70488322b622cb33829ca97c