### PR TITLE
Allow manual MoveTo steps to execute without strict target matches

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -3488,6 +3488,7 @@ public sealed class GoapSimulationView : MonoBehaviour
             actionable = true;
         }
 
+        bool requiresStrictTargetMatch = actionable;
         return new PlanActionOption(
             formattedLabel,
             trimmed,
@@ -3496,7 +3497,8 @@ public sealed class GoapSimulationView : MonoBehaviour
             targetPosition,
             stepIndex,
             actionable,
-            normalizedGoalId);
+            normalizedGoalId,
+            requiresStrictTargetMatch);
     }
 
     private static string ExtractPlanActivityIdentifier(string stepLabel)
@@ -3596,13 +3598,18 @@ public sealed class GoapSimulationView : MonoBehaviour
                 $"Selected pawn '{selectedId.Value}' is not controlled by the player pawn controller.");
         }
 
+        ThingId? expectedPlanTargetId = option.RequiresStrictTargetMatch ? option.TargetId : (ThingId?)null;
+        GridPos? expectedPlanTargetPosition = option.RequiresStrictTargetMatch ? option.TargetPosition : (GridPos?)null;
         playerPawnController.RequestManualInteract(
             option.TargetId.Value,
             option.TargetPosition.Value,
             option.StepIndex,
             _selectedPawnPlanSnapshotVersion,
             option.ActivityId,
-            participationGoalId);
+            participationGoalId,
+            expectedPlanTargetId,
+            expectedPlanTargetPosition,
+            option.RequiresStrictTargetMatch);
         _selectedPlanOptionIndex = participationIndex;
         _selectedPlanOptionLabel = participationIndex < _selectedThingPlanLines.Length
             ? _selectedThingPlanLines[participationIndex]
@@ -3812,7 +3819,8 @@ public sealed class GoapSimulationView : MonoBehaviour
             _selectedThingGridPosition.Value,
             0,
             true,
-            goalId);
+            goalId,
+            requiresStrictTargetMatch: false);
     }
 
     private static bool NullableThingIdEquals(ThingId? left, ThingId? right)
@@ -3840,7 +3848,8 @@ public sealed class GoapSimulationView : MonoBehaviour
             GridPos? targetPosition,
             int stepIndex,
             bool isActionable,
-            string goalId)
+            string goalId,
+            bool requiresStrictTargetMatch)
         {
             if (string.IsNullOrWhiteSpace(label))
             {
@@ -3870,6 +3879,7 @@ public sealed class GoapSimulationView : MonoBehaviour
             StepIndex = stepIndex;
             IsActionable = isActionable;
             GoalId = goalId.Trim();
+            RequiresStrictTargetMatch = requiresStrictTargetMatch;
             if (GoalId.Length == 0)
             {
                 throw new ArgumentException(
@@ -3885,6 +3895,7 @@ public sealed class GoapSimulationView : MonoBehaviour
         public int StepIndex { get; }
         public bool IsActionable { get; }
         public string GoalId { get; }
+        public bool RequiresStrictTargetMatch { get; }
     }
 
     private sealed class ThingVisual

--- a/Assets/Scripts/PlayerPawnController.cs
+++ b/Assets/Scripts/PlayerPawnController.cs
@@ -242,7 +242,10 @@ public sealed class PlayerPawnController : MonoBehaviour
         int? planStepIndex = null,
         long? expectedSnapshotVersion = null,
         string planStepActivity = null,
-        string planGoalId = null)
+        string planGoalId = null,
+        ThingId? expectedPlanTargetId = null,
+        GridPos? expectedPlanTargetPosition = null,
+        bool enforceExpectedTarget = true)
     {
         if (_world == null)
         {
@@ -285,8 +288,18 @@ public sealed class PlayerPawnController : MonoBehaviour
                     "Manual plan execution requires a non-empty goal identifier after trimming.");
             }
 
-            var expectedTarget = hasTarget ? (ThingId?)targetId : null;
-            var expectedPosition = hasTarget ? (GridPos?)targetPos : null;
+            ThingId? expectedTarget;
+            GridPos? expectedPosition;
+            if (enforceExpectedTarget)
+            {
+                expectedTarget = expectedPlanTargetId ?? (hasTarget ? (ThingId?)targetId : null);
+                expectedPosition = expectedPlanTargetPosition ?? (hasTarget ? (GridPos?)targetPos : null);
+            }
+            else
+            {
+                expectedTarget = expectedPlanTargetId;
+                expectedPosition = expectedPlanTargetPosition;
+            }
             updatedSnapshotVersion = bootstrapper.ExecuteManualPlanStepSequence(
                 _playerPawnId.Value,
                 planStepIndex.Value,


### PR DESCRIPTION
## Summary
- capture whether a plan option requires a strict target match when invoking manual execution
- allow manual interaction requests to opt out of enforcing a plan target so fallback options can execute

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3dc60c7cc83228077ebc0e5daed2a