### PR TITLE
Disable manual fallback plan execution

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -3916,14 +3916,17 @@ public sealed class GoapSimulationView : MonoBehaviour
             rawLabel = label;
         }
 
+        // Fallback options surface participation details in the UI but should not be executable
+        // because they do not originate from a resolved manual plan. Present them as disabled
+        // entries by marking the option non-actionable and using a sentinel step index.
         return new PlanActionOption(
             label,
             rawLabel,
             activityId,
             _selectedThingId.Value,
             _selectedThingGridPosition.Value,
-            0,
-            true,
+            -1,
+            false,
             goalId,
             requiresStrictTargetMatch: false);
     }


### PR DESCRIPTION
## Summary
- mark fallback plan options in the manual plan UI as non-actionable to avoid invoking missing plans
- document why fallback entries remain visible but disabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3fbc770e88322ae489b9d8b1ef850