### PR TITLE
Ensure inventory grid UI is created at runtime

### DIFF
--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -175,6 +175,7 @@ public sealed class GoapSimulationView : MonoBehaviour
     {
         EnsureBootstrapperReference();
         EnsureObserverCamera();
+        EnsureInventoryGridPresenter();
     }
 
     private void RenderThingInventoryPanel(
@@ -304,6 +305,7 @@ public sealed class GoapSimulationView : MonoBehaviour
     {
         EnsureBootstrapperReference();
         EnsureObserverCamera();
+        EnsureInventoryGridPresenter();
         bootstrapper.Bootstrapped += HandleBootstrapped;
         if (bootstrapper.HasBootstrapped && _world == null)
         {
@@ -2995,6 +2997,33 @@ public sealed class GoapSimulationView : MonoBehaviour
         if (bootstrapper == null)
         {
             throw new InvalidOperationException("GoapSimulationView could not locate a GoapSimulationBootstrapper in the scene.");
+        }
+
+        EnsureInventoryGridPresenter();
+    }
+
+    private void EnsureInventoryGridPresenter()
+    {
+        if (bootstrapper == null)
+        {
+            return;
+        }
+
+        if (inventoryGridPresenter == null)
+        {
+            var presenterObject = new GameObject("Inventory Grid Presenter");
+            presenterObject.SetActive(false);
+            presenterObject.transform.SetParent(transform, false);
+
+            var presenter = presenterObject.AddComponent<InventoryGridPresenter>();
+            presenter.ConfigureDependencies(bootstrapper, this, null);
+            presenterObject.SetActive(true);
+
+            inventoryGridPresenter = presenter;
+        }
+        else
+        {
+            inventoryGridPresenter.ConfigureDependencies(bootstrapper, this, null);
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure the simulation view creates and wires an inventory grid presenter when no scene reference exists
- update the inventory grid presenter to support runtime dependency injection and build a styled layout when no UXML is provided

## Testing
- not run (editor-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e3fc33229c832287332ca53008f2dd