### PR TITLE
Fix inventory grid styling for Unity compatibility

### DIFF
--- a/Assets/Scripts/UI/InventoryGridPresenter.cs
+++ b/Assets/Scripts/UI/InventoryGridPresenter.cs
@@ -345,7 +345,6 @@ public sealed class InventoryGridPresenter : MonoBehaviour
         panel.style.borderBottomLeftRadius = 8f;
         panel.style.borderBottomRightRadius = 8f;
         panel.style.flexDirection = FlexDirection.Column;
-        panel.style.rowGap = 6f;
     }
 
     private static void ApplyTitleStyle(Label title)
@@ -353,20 +352,21 @@ public sealed class InventoryGridPresenter : MonoBehaviour
         title.style.unityFontStyleAndWeight = FontStyle.Bold;
         title.style.fontSize = 14f;
         title.style.color = Color.white;
+        title.style.marginBottom = 6f;
     }
 
     private static void ApplyGridStyle(VisualElement grid)
     {
         grid.style.flexDirection = FlexDirection.Row;
         grid.style.flexWrap = Wrap.Wrap;
-        grid.style.rowGap = 4f;
-        grid.style.columnGap = 4f;
+        grid.style.marginBottom = 6f;
     }
 
     private static void ApplyEmptyLabelStyle(Label emptyLabel)
     {
         emptyLabel.style.color = new StyleColor(new Color(1f, 1f, 1f, 0.7f));
         emptyLabel.style.fontSize = 12f;
+        emptyLabel.style.marginTop = 6f;
     }
 
     private static void ApplySlotStyle(VisualElement slot)
@@ -389,6 +389,8 @@ public sealed class InventoryGridPresenter : MonoBehaviour
         slot.style.flexShrink = 0f;
         slot.style.flexGrow = 0f;
         slot.style.position = Position.Relative;
+        slot.style.marginRight = 4f;
+        slot.style.marginBottom = 4f;
     }
 
     private static void ApplyQuantityLabelStyle(Label quantityLabel)

--- a/Assets/UI/Inventory/InventoryGrid.uss
+++ b/Assets/UI/Inventory/InventoryGrid.uss
@@ -50,7 +50,7 @@
   right: 4px;
   font-size: 11px;
   color: white;
-  -unity-text-outline-width: 0.4;
+  -unity-text-outline-width: 0.4px;
   -unity-text-outline-color: rgba(0, 0, 0, 0.8);
   -unity-font-style: bold;
 }


### PR DESCRIPTION
## Summary
- replace unsupported UI Toolkit row/column gap usage with element margins in the inventory grid presenter
- add explicit outline width units to the inventory grid USS to silence style warnings

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3fecf12e88322a2c7579d009be888