### PR TITLE
Add UI Toolkit inventory panel asset

### DIFF
--- a/Assets/UI/Inventory/InventoryPanel.uss
+++ b/Assets/UI/Inventory/InventoryPanel.uss
@@ -1,0 +1,116 @@
+.inventory-panel {
+  padding: 12px 16px 16px 16px;
+  background-color: rgba(12, 16, 24, 0.92);
+  border-radius: 10px;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.12);
+  flex-direction: column;
+  gap: 12px;
+  min-width: 420px;
+}
+
+.inventory-panel__header {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.inventory-panel__title {
+  color: white;
+  font-size: 18px;
+  -unity-font-style: bold;
+  letter-spacing: 0.5px;
+}
+
+.inventory-panel__actions {
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.inventory-panel__search {
+  width: 180px;
+}
+
+.inventory-panel__button {
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  border-radius: 6px;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.18);
+  background-color: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.inventory-panel__button--sort,
+.inventory-panel__button--filter {
+  min-width: 64px;
+}
+
+.inventory-panel__content {
+  flex-direction: row;
+  gap: 16px;
+}
+
+.inventory-panel__equipment {
+  width: 140px;
+  padding: 10px;
+  border-radius: 8px;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(255, 255, 255, 0.04);
+  flex-direction: column;
+  gap: 8px;
+}
+
+.inventory-panel__section-title {
+  font-size: 14px;
+  -unity-font-style: bold;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.inventory-panel__equipment-slots {
+  flex-grow: 1;
+  gap: 6px;
+  flex-direction: column;
+}
+
+.inventory-panel__divider {
+  width: 1px;
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.inventory-panel__inventory {
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 8px;
+}
+
+.inventory-panel__grid {
+  min-height: 160px;
+  padding: 6px;
+  border-radius: 8px;
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0.08);
+  background-color: rgba(255, 255, 255, 0.03);
+}
+
+.inventory-panel__empty-message {
+  margin-top: 4px;
+}
+
+.inventory-panel__footer {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 4px;
+  border-top-width: 1px;
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.inventory-panel__footer-text {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.75);
+}

--- a/Assets/UI/Inventory/InventoryPanel.uss.meta
+++ b/Assets/UI/Inventory/InventoryPanel.uss.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e96ecbb342e94ec5bbe64b657f32b520
+StyleSheetImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UI/Inventory/InventoryPanel.uxml
+++ b/Assets/UI/Inventory/InventoryPanel.uxml
@@ -1,0 +1,30 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+  <ui:Style src="InventoryPanel.uss" />
+  <ui:Style src="InventoryGrid.uss" />
+  <ui:VisualElement name="InventoryPanel" class="inventory-panel">
+    <ui:VisualElement class="inventory-panel__header">
+      <ui:Label name="PanelTitle" text="Inventory" class="inventory-panel__title" />
+      <ui:VisualElement class="inventory-panel__actions">
+        <ui:TextField name="SearchField" label="Search" class="inventory-panel__search" />
+        <ui:Button name="SortButton" text="Sort" class="inventory-panel__button inventory-panel__button--sort" />
+        <ui:Button name="FilterButton" text="Filter" class="inventory-panel__button inventory-panel__button--filter" />
+      </ui:VisualElement>
+    </ui:VisualElement>
+    <ui:VisualElement class="inventory-panel__content">
+      <ui:VisualElement class="inventory-panel__equipment">
+        <ui:Label text="Equipment" class="inventory-panel__section-title" />
+        <ui:VisualElement name="EquipmentSlots" class="inventory-panel__equipment-slots" />
+      </ui:VisualElement>
+      <ui:VisualElement class="inventory-panel__divider" />
+      <ui:VisualElement class="inventory-panel__inventory">
+        <ui:Label text="Backpack" class="inventory-panel__section-title" />
+        <ui:VisualElement name="InventoryGrid" class="inv-grid inventory-panel__grid" />
+        <ui:Label name="EmptyMessage" text="No items" class="inv-empty inventory-panel__empty-message" style="display: none;" />
+      </ui:VisualElement>
+    </ui:VisualElement>
+    <ui:VisualElement class="inventory-panel__footer">
+      <ui:Label name="WeightLabel" text="Weight: 0 / 100" class="inventory-panel__footer-text" />
+      <ui:Label name="CurrencyLabel" text="Coins: 0" class="inventory-panel__footer-text" />
+    </ui:VisualElement>
+  </ui:VisualElement>
+</ui:UXML>

--- a/Assets/UI/Inventory/InventoryPanel.uxml.meta
+++ b/Assets/UI/Inventory/InventoryPanel.uxml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 820457bd3e794318b40a870c11791bee
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a new InventoryPanel UXML layout that organizes header, equipment slots, grid, and footer information
- provide companion USS styling for the new panel and reuse existing grid styles for consistency

## Testing
- not run (UI asset only)


------
https://chatgpt.com/codex/tasks/task_e_68e418c636e48322a651147d342bbb58