### PR TITLE
Create runtime inventory panel settings asset

### DIFF
--- a/Assets/Resources/UI/Inventory/InventoryPanelSettings.asset
+++ b/Assets/Resources/UI/Inventory/InventoryPanelSettings.asset
@@ -9,16 +9,15 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 3}
+  m_Script: {fileID: 11500000, guid: 439d0a86c8334fd3bfb9ea37cf586385, type: 3}
   m_Name: InventoryPanelSettings
-  m_EditorClassIdentifier: 
-  themeUss: {fileID: 0}
-  themeStyleSheet: {fileID: 0}
+  m_EditorClassIdentifier:
   scaleMode: 1
   referenceResolution: {x: 1920, y: 1080}
   referenceDpi: 96
   match: 0
   screenMatchMode: 0
+  scale: 1
   targetTexture: {fileID: 0}
   clearDepthStencil: 1
   maxQueuedFrames: 8
@@ -26,7 +25,6 @@ MonoBehaviour:
   textSettings: {fileID: 0}
   targetDisplay: 0
   drawToCameras: 1
-  scale: 1
   viewport: {x: 0, y: 0, width: 1, height: 1}
   vsync: 1
   targetWidth: 0
@@ -42,4 +40,3 @@ MonoBehaviour:
   runtimeWorldSpacePanelSettings: {fileID: 0}
   antiAliasing: 4
   pixelsPerUnit: 100
-  assetVersion: 3

--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -175,6 +175,7 @@ public sealed class GoapSimulationView : MonoBehaviour
     private string _lastPresenterInventoryHeader = string.Empty;
     private Rect? _lastSelectedPawnPanelRect;
     private Rect? _lastSelectedThingPlanPanelRect;
+    private InventoryPanelSettingsAsset _inventoryPanelSettingsAsset;
     private PanelSettings _inventoryPanelSettings;
 
     private void Awake()
@@ -333,6 +334,13 @@ public sealed class GoapSimulationView : MonoBehaviour
         {
             bootstrapper.Bootstrapped -= HandleBootstrapped;
         }
+
+        if (_inventoryPanelSettings != null)
+        {
+            Destroy(_inventoryPanelSettings);
+            _inventoryPanelSettings = null;
+        }
+
         DisposeVisuals();
     }
 
@@ -3169,6 +3177,25 @@ public sealed class GoapSimulationView : MonoBehaviour
         EnsureInventoryGridPresenter();
     }
 
+    private InventoryPanelSettingsAsset GetInventoryPanelSettingsAsset()
+    {
+        if (_inventoryPanelSettingsAsset != null)
+        {
+            return _inventoryPanelSettingsAsset;
+        }
+
+        var loaded = Resources.Load<InventoryPanelSettingsAsset>(InventoryPanelSettingsResourcePath);
+        if (loaded == null)
+        {
+            throw new InvalidOperationException(
+                $"Inventory panel settings asset not found at Resources/{InventoryPanelSettingsResourcePath}. " +
+                $"An {nameof(InventoryPanelSettingsAsset)} asset is required for the inventory UI.");
+        }
+
+        _inventoryPanelSettingsAsset = loaded;
+        return _inventoryPanelSettingsAsset;
+    }
+
     private PanelSettings GetInventoryPanelSettings()
     {
         if (_inventoryPanelSettings != null)
@@ -3176,15 +3203,15 @@ public sealed class GoapSimulationView : MonoBehaviour
             return _inventoryPanelSettings;
         }
 
-        var loaded = Resources.Load<PanelSettings>(InventoryPanelSettingsResourcePath);
-        if (loaded == null)
+        var definition = GetInventoryPanelSettingsAsset();
+        var created = definition.CreateRuntimePanelSettings();
+        if (created == null)
         {
             throw new InvalidOperationException(
-                $"Inventory panel settings asset not found at Resources/{InventoryPanelSettingsResourcePath}. " +
-                "A PanelSettings asset is required for the inventory UI.");
+                "Inventory panel settings asset failed to create a runtime PanelSettings instance.");
         }
 
-        _inventoryPanelSettings = loaded;
+        _inventoryPanelSettings = created;
         return _inventoryPanelSettings;
     }
 

--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+[CreateAssetMenu(menuName = "UI/Inventory Panel Settings", fileName = "InventoryPanelSettings")]
+public sealed class InventoryPanelSettingsAsset : ScriptableObject
+{
+    [Header("Scaling")]
+    [SerializeField] private PanelScaleMode scaleMode = PanelScaleMode.ScaleWithScreenSize;
+    [SerializeField] private Vector2 referenceResolution = new Vector2(1920f, 1080f);
+    [SerializeField, Min(1f)] private float referenceDpi = 96f;
+    [SerializeField, Range(0f, 1f)] private float match = 0f;
+    [SerializeField] private PanelScreenMatchMode screenMatchMode = PanelScreenMatchMode.MatchWidthOrHeight;
+    [SerializeField, Min(0.01f)] private float scale = 1f;
+
+    [Header("Rendering")]
+    [SerializeField] private RenderTexture targetTexture;
+    [SerializeField] private bool clearDepthStencil = true;
+    [SerializeField] private int maxQueuedFrames = 8;
+    [SerializeField] private PanelSettings.PanelClearFlags panelClearFlags = PanelSettings.PanelClearFlags.DepthStencil;
+    [SerializeField] private PanelTextSettings textSettings;
+    [SerializeField, Min(0)] private int targetDisplay = 0;
+    [SerializeField] private bool drawToCameras = true;
+    [SerializeField] private Rect viewport = new Rect(0f, 0f, 1f, 1f);
+    [SerializeField] private bool vsync = true;
+    [SerializeField, Min(0f)] private float targetWidth;
+    [SerializeField, Min(0f)] private float targetHeight;
+    [SerializeField] private int worldSpaceLayer;
+    [SerializeField] private int sortingOrder;
+    [SerializeField] private LayerMask targetLayerMask = ~0;
+    [SerializeField] private PanelSettings.RuntimePanelRenderingMode renderingMode = PanelSettings.RuntimePanelRenderingMode.Camera;
+    [SerializeField, Min(0)] private int vsyncCount = 1;
+    [SerializeField] private Shader runtimeShader;
+    [SerializeField] private PanelSettings runtimeWorldSpacePanelSettings;
+    [SerializeField, Min(0)] private int antiAliasing = 4;
+    [SerializeField, Min(0.01f)] private float pixelsPerUnit = 100f;
+
+    public PanelSettings CreateRuntimePanelSettings()
+    {
+        var instance = ScriptableObject.CreateInstance<PanelSettings>();
+        instance.hideFlags = HideFlags.HideAndDontSave;
+        instance.name = $"{name}_Runtime";
+
+        instance.scaleMode = scaleMode;
+        instance.referenceResolution = referenceResolution;
+        instance.referenceDpi = referenceDpi;
+        instance.match = match;
+        instance.screenMatchMode = screenMatchMode;
+        instance.scale = scale;
+        instance.targetTexture = targetTexture;
+        instance.clearDepthStencil = clearDepthStencil;
+        instance.panelClearFlags = panelClearFlags;
+        instance.textSettings = textSettings;
+        instance.targetDisplay = targetDisplay;
+        instance.drawToCameras = drawToCameras;
+        instance.viewport = viewport;
+        instance.vsync = vsync;
+        instance.targetWidth = targetWidth;
+        instance.targetHeight = targetHeight;
+        instance.sortingOrder = sortingOrder;
+        instance.renderingMode = renderingMode;
+        instance.vsyncCount = vsyncCount;
+        instance.runtimeShader = runtimeShader;
+        instance.runtimeWorldSpacePanelSettings = runtimeWorldSpacePanelSettings;
+        instance.antiAliasing = antiAliasing;
+        instance.pixelsPerUnit = pixelsPerUnit;
+
+        TryAssignOptional(instance, nameof(maxQueuedFrames), maxQueuedFrames);
+        TryAssignOptional(instance, nameof(worldSpaceLayer), worldSpaceLayer);
+        TryAssignTargetLayerMask(instance, targetLayerMask);
+
+        return instance;
+    }
+
+    private static void TryAssignOptional<T>(PanelSettings target, string memberName, T value)
+    {
+        var type = target.GetType();
+        var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null && property.CanWrite && property.PropertyType.IsAssignableFrom(typeof(T)))
+        {
+            property.SetValue(target, value);
+            return;
+        }
+
+        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null && field.FieldType.IsAssignableFrom(typeof(T)))
+        {
+            field.SetValue(target, value);
+        }
+    }
+
+    private static void TryAssignTargetLayerMask(PanelSettings target, LayerMask mask)
+    {
+        var type = target.GetType();
+        var property = type.GetProperty("targetLayerMask", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null && property.CanWrite)
+        {
+            if (property.PropertyType == typeof(LayerMask))
+            {
+                property.SetValue(target, mask);
+                return;
+            }
+
+            if (property.PropertyType == typeof(int))
+            {
+                property.SetValue(target, mask.value);
+                return;
+            }
+
+            if (property.PropertyType == typeof(uint))
+            {
+                property.SetValue(target, Convert.ToUInt32(mask.value));
+                return;
+            }
+        }
+
+        var field = type.GetField("targetLayerMask", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null)
+        {
+            if (field.FieldType == typeof(LayerMask))
+            {
+                field.SetValue(target, mask);
+            }
+            else if (field.FieldType == typeof(int))
+            {
+                field.SetValue(target, mask.value);
+            }
+            else if (field.FieldType == typeof(uint))
+            {
+                field.SetValue(target, Convert.ToUInt32(mask.value));
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs.meta
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 439d0a86c8334fd3bfb9ea37cf586385
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add an InventoryPanelSettingsAsset ScriptableObject that builds a runtime PanelSettings instance with the project’s desired defaults
- update GoapSimulationView to load the asset, create the panel settings at runtime, and dispose of it during teardown
- reserialize the InventoryPanelSettings asset so it references the new definition

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e42928a2088322b8185bfa38eeaa77