### PR TITLE
Handle PanelSettings property type changes in inventory UI asset

### DIFF
--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
@@ -8,7 +8,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
 {
     [Header("Scaling")]
     [SerializeField] private PanelScaleMode scaleMode = PanelScaleMode.ScaleWithScreenSize;
-    [SerializeField] private Vector2 referenceResolution = new Vector2(1920f, 1080f);
+    [SerializeField] private Vector2Int referenceResolution = new Vector2Int(1920, 1080);
     [SerializeField, Min(1f)] private float referenceDpi = 96f;
     [SerializeField, Range(0f, 1f)] private float match = 0f;
     [SerializeField] private PanelScreenMatchMode screenMatchMode = PanelScreenMatchMode.MatchWidthOrHeight;
@@ -18,7 +18,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
     [SerializeField] private RenderTexture targetTexture;
     [SerializeField] private bool clearDepthStencil = true;
     [SerializeField] private int maxQueuedFrames = 8;
-    [SerializeField] private PanelSettings.PanelClearFlags panelClearFlags = PanelSettings.PanelClearFlags.DepthStencil;
+    [SerializeField] private PanelClearFlagsOption panelClearFlags = PanelClearFlagsOption.DepthStencil;
     [SerializeField] private PanelTextSettings textSettings;
     [SerializeField, Min(0)] private int targetDisplay = 0;
     [SerializeField] private bool drawToCameras = true;
@@ -29,7 +29,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
     [SerializeField] private int worldSpaceLayer;
     [SerializeField] private int sortingOrder;
     [SerializeField] private LayerMask targetLayerMask = ~0;
-    [SerializeField] private PanelSettings.RuntimePanelRenderingMode renderingMode = PanelSettings.RuntimePanelRenderingMode.Camera;
+    [SerializeField] private RuntimePanelRenderingModeOption renderingMode = RuntimePanelRenderingModeOption.Camera;
     [SerializeField, Min(0)] private int vsyncCount = 1;
     [SerializeField] private Shader runtimeShader;
     [SerializeField] private PanelSettings runtimeWorldSpacePanelSettings;
@@ -42,51 +42,270 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         instance.hideFlags = HideFlags.HideAndDontSave;
         instance.name = $"{name}_Runtime";
 
-        instance.scaleMode = scaleMode;
-        instance.referenceResolution = referenceResolution;
-        instance.referenceDpi = referenceDpi;
-        instance.match = match;
-        instance.screenMatchMode = screenMatchMode;
-        instance.scale = scale;
-        instance.targetTexture = targetTexture;
-        instance.clearDepthStencil = clearDepthStencil;
-        instance.panelClearFlags = panelClearFlags;
-        instance.textSettings = textSettings;
-        instance.targetDisplay = targetDisplay;
-        instance.drawToCameras = drawToCameras;
-        instance.viewport = viewport;
-        instance.vsync = vsync;
-        instance.targetWidth = targetWidth;
-        instance.targetHeight = targetHeight;
-        instance.sortingOrder = sortingOrder;
-        instance.renderingMode = renderingMode;
-        instance.vsyncCount = vsyncCount;
-        instance.runtimeShader = runtimeShader;
-        instance.runtimeWorldSpacePanelSettings = runtimeWorldSpacePanelSettings;
-        instance.antiAliasing = antiAliasing;
-        instance.pixelsPerUnit = pixelsPerUnit;
+        AssignRequired(instance, ScaleModeMemberName, scaleMode);
+        AssignRequired(instance, ReferenceResolutionMemberName, referenceResolution);
+        AssignRequired(instance, ReferenceDpiMemberName, referenceDpi);
+        AssignRequired(instance, MatchMemberName, match);
+        AssignRequired(instance, ScreenMatchModeMemberName, screenMatchMode);
+        AssignRequired(instance, ScaleMemberName, scale);
+        TryAssignOptional(instance, TargetTextureMemberName, targetTexture);
+        AssignRequired(instance, ClearDepthStencilMemberName, clearDepthStencil);
+        AssignEnumValue(instance, PanelClearFlagsMemberName, GetPanelClearFlagsName(panelClearFlags));
+        TryAssignOptional(instance, TextSettingsMemberName, textSettings);
+        AssignRequired(instance, TargetDisplayMemberName, targetDisplay);
+        TryAssignOptional(instance, DrawToCamerasMemberName, drawToCameras);
+        TryAssignOptional(instance, ViewportMemberName, viewport);
+        TryAssignOptional(instance, VsyncMemberName, vsync);
+        TryAssignOptional(instance, TargetWidthMemberName, targetWidth);
+        TryAssignOptional(instance, TargetHeightMemberName, targetHeight);
+        AssignRequired(instance, SortingOrderMemberName, sortingOrder);
+        AssignEnumValue(instance, RenderingModeMemberName, GetRuntimePanelRenderingModeName(renderingMode));
+        TryAssignOptional(instance, VsyncCountMemberName, vsyncCount);
+        TryAssignOptional(instance, RuntimeShaderMemberName, runtimeShader);
+        TryAssignOptional(instance, RuntimeWorldSpacePanelSettingsMemberName, runtimeWorldSpacePanelSettings);
+        TryAssignOptional(instance, AntiAliasingMemberName, antiAliasing);
+        TryAssignOptional(instance, PixelsPerUnitMemberName, pixelsPerUnit);
 
-        TryAssignOptional(instance, nameof(maxQueuedFrames), maxQueuedFrames);
-        TryAssignOptional(instance, nameof(worldSpaceLayer), worldSpaceLayer);
+        TryAssignOptional(instance, MaxQueuedFramesMemberName, maxQueuedFrames);
+        TryAssignOptional(instance, WorldSpaceLayerMemberName, worldSpaceLayer);
         TryAssignTargetLayerMask(instance, targetLayerMask);
 
         return instance;
     }
 
-    private static void TryAssignOptional<T>(PanelSettings target, string memberName, T value)
+    private const string ScaleModeMemberName = nameof(PanelSettings.scaleMode);
+    private const string ReferenceResolutionMemberName = "referenceResolution";
+    private const string ReferenceDpiMemberName = nameof(PanelSettings.referenceDpi);
+    private const string MatchMemberName = nameof(PanelSettings.match);
+    private const string ScreenMatchModeMemberName = nameof(PanelSettings.screenMatchMode);
+    private const string ScaleMemberName = nameof(PanelSettings.scale);
+    private const string TargetTextureMemberName = nameof(PanelSettings.targetTexture);
+    private const string ClearDepthStencilMemberName = nameof(PanelSettings.clearDepthStencil);
+    private const string PanelClearFlagsMemberName = "panelClearFlags";
+    private const string TextSettingsMemberName = nameof(PanelSettings.textSettings);
+    private const string TargetDisplayMemberName = nameof(PanelSettings.targetDisplay);
+    private const string DrawToCamerasMemberName = "drawToCameras";
+    private const string ViewportMemberName = "viewport";
+    private const string VsyncMemberName = "vsync";
+    private const string TargetWidthMemberName = "targetWidth";
+    private const string TargetHeightMemberName = "targetHeight";
+    private const string SortingOrderMemberName = nameof(PanelSettings.sortingOrder);
+    private const string RenderingModeMemberName = "renderingMode";
+    private const string VsyncCountMemberName = "vsyncCount";
+    private const string RuntimeShaderMemberName = "runtimeShader";
+    private const string RuntimeWorldSpacePanelSettingsMemberName = "runtimeWorldSpacePanelSettings";
+    private const string AntiAliasingMemberName = "antiAliasing";
+    private const string PixelsPerUnitMemberName = "pixelsPerUnit";
+    private const string MaxQueuedFramesMemberName = "maxQueuedFrames";
+    private const string WorldSpaceLayerMemberName = "worldSpaceLayer";
+
+    [Flags]
+    private enum PanelClearFlagsOption
+    {
+        None = 0,
+        Color = 1,
+        Depth = 2,
+        Stencil = 4,
+        DepthStencil = Depth | Stencil,
+        All = Color | Depth | Stencil
+    }
+
+    private enum RuntimePanelRenderingModeOption
+    {
+        Disabled = 0,
+        Camera = 1,
+        WorldSpace = 2
+    }
+
+    private static string GetPanelClearFlagsName(PanelClearFlagsOption option)
+    {
+        return option switch
+        {
+            PanelClearFlagsOption.None => "None",
+            PanelClearFlagsOption.Color => "Color",
+            PanelClearFlagsOption.Depth => "Depth",
+            PanelClearFlagsOption.Stencil => "Stencil",
+            PanelClearFlagsOption.DepthStencil => "DepthStencil",
+            PanelClearFlagsOption.All => "All",
+            _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
+        };
+    }
+
+    private static string GetRuntimePanelRenderingModeName(RuntimePanelRenderingModeOption option)
+    {
+        return option switch
+        {
+            RuntimePanelRenderingModeOption.Disabled => "Disabled",
+            RuntimePanelRenderingModeOption.Camera => "Camera",
+            RuntimePanelRenderingModeOption.WorldSpace => "WorldSpace",
+            _ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
+        };
+    }
+
+    private static void AssignRequired<T>(PanelSettings target, string memberName, T value)
+    {
+        if (!TryAssignOptional(target, memberName, value))
+        {
+            throw new MissingMemberException(target.GetType().FullName, memberName);
+        }
+    }
+
+    private static bool TryAssignOptional<T>(PanelSettings target, string memberName, T value)
     {
         var type = target.GetType();
         var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        if (property != null && property.CanWrite && property.PropertyType.IsAssignableFrom(typeof(T)))
+        if (property != null && property.CanWrite && TryConvertValue(value, property.PropertyType, out var convertedPropertyValue))
         {
+            property.SetValue(target, convertedPropertyValue);
+            return true;
+        }
+
+        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null && TryConvertValue(value, field.FieldType, out var convertedFieldValue))
+        {
+            field.SetValue(target, convertedFieldValue);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryConvertValue<T>(T value, Type targetType, out object converted)
+    {
+        if (value == null)
+        {
+            if (!targetType.IsValueType || Nullable.GetUnderlyingType(targetType) != null)
+            {
+                converted = null;
+                return true;
+            }
+
+            converted = null;
+            return false;
+        }
+
+        var valueType = value.GetType();
+        if (targetType.IsAssignableFrom(valueType))
+        {
+            converted = value;
+            return true;
+        }
+
+        if (targetType.IsEnum)
+        {
+            if (value is string enumName)
+            {
+                converted = Enum.Parse(targetType, enumName, false);
+                return true;
+            }
+
+            if (IsNumericType(valueType))
+            {
+                converted = Enum.ToObject(targetType, value);
+                return true;
+            }
+        }
+
+        if (IsNumericType(valueType) && IsNumericType(targetType))
+        {
+            converted = Convert.ChangeType(value, targetType);
+            return true;
+        }
+
+        if (targetType == typeof(Vector2Int) && value is Vector2 vectorValue)
+        {
+            converted = Vector2Int.RoundToInt(vectorValue);
+            return true;
+        }
+
+        if (targetType == typeof(Vector2) && value is Vector2Int vectorIntValue)
+        {
+            converted = (Vector2)vectorIntValue;
+            return true;
+        }
+
+        if (targetType == typeof(RectInt) && value is Rect rectValue)
+        {
+            converted = new RectInt(
+                Mathf.RoundToInt(rectValue.xMin),
+                Mathf.RoundToInt(rectValue.yMin),
+                Mathf.RoundToInt(rectValue.width),
+                Mathf.RoundToInt(rectValue.height));
+            return true;
+        }
+
+        if (targetType == typeof(Rect) && value is RectInt rectIntValue)
+        {
+            converted = new Rect(rectIntValue.x, rectIntValue.y, rectIntValue.width, rectIntValue.height);
+            return true;
+        }
+
+        converted = null;
+        return false;
+    }
+
+    private static bool IsNumericType(Type type)
+    {
+        switch (Type.GetTypeCode(type))
+        {
+            case TypeCode.Byte:
+            case TypeCode.SByte:
+            case TypeCode.UInt16:
+            case TypeCode.UInt32:
+            case TypeCode.UInt64:
+            case TypeCode.Int16:
+            case TypeCode.Int32:
+            case TypeCode.Int64:
+            case TypeCode.Decimal:
+            case TypeCode.Double:
+            case TypeCode.Single:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static void AssignEnumValue(PanelSettings target, string memberName, string enumName)
+    {
+        if (string.IsNullOrEmpty(enumName))
+        {
+            return;
+        }
+
+        var type = target.GetType();
+        var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null && property.CanWrite)
+        {
+            var value = CreateEnumValue(property.PropertyType, enumName, memberName);
             property.SetValue(target, value);
             return;
         }
 
         var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        if (field != null && field.FieldType.IsAssignableFrom(typeof(T)))
+        if (field != null)
         {
+            var value = CreateEnumValue(field.FieldType, enumName, memberName);
             field.SetValue(target, value);
+            return;
+        }
+
+        throw new MissingMemberException(type.FullName, memberName);
+    }
+
+    private static object CreateEnumValue(Type enumType, string enumName, string memberName)
+    {
+        if (!enumType.IsEnum)
+        {
+            throw new InvalidOperationException($"Member '{memberName}' on '{enumType.FullName}' is not an enum.");
+        }
+
+        try
+        {
+            return Enum.Parse(enumType, enumName, false);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidOperationException($"Value '{enumName}' is not defined for enum '{enumType.FullName}'.", exception);
         }
     }
 


### PR DESCRIPTION
## Summary
- store the reference resolution as a `Vector2Int` and rely on conversion helpers so both legacy `Vector2` and new integer-backed PanelSettings APIs are supported
- centralize PanelSettings member names and drive all assignments through the reflective helper methods so removed properties are skipped without compile errors while required members still throw when missing

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e42bce5a9c8322a8916d572e71aeda