### PR TITLE
Handle PanelSettings rendering mode across Unity API changes

### DIFF
--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
@@ -59,7 +59,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         TryAssignOptional(instance, TargetWidthMemberName, targetWidth);
         TryAssignOptional(instance, TargetHeightMemberName, targetHeight);
         AssignRequired(instance, SortingOrderMemberName, sortingOrder);
-        AssignEnumValue(instance, RenderingModeMemberName, GetRuntimePanelRenderingModeName(renderingMode));
+        AssignRenderingMode(instance, GetRuntimePanelRenderingModeName(renderingMode));
         TryAssignOptional(instance, VsyncCountMemberName, vsyncCount);
         TryAssignOptional(instance, RuntimeShaderMemberName, runtimeShader);
         TryAssignOptional(instance, RuntimeWorldSpacePanelSettingsMemberName, runtimeWorldSpacePanelSettings);
@@ -93,6 +93,8 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
     private const string TargetHeightMemberName = "targetHeight";
     private const string SortingOrderMemberName = nameof(PanelSettings.sortingOrder);
     private const string RenderingModeMemberName = "renderingMode";
+    private const string RuntimePanelCreationSettingsMemberName = "runtimePanelCreationSettings";
+    private const string RuntimePanelSettingsMemberName = "runtimePanelSettings";
     private const string VsyncCountMemberName = "vsyncCount";
     private const string RuntimeShaderMemberName = "runtimeShader";
     private const string RuntimeWorldSpacePanelSettingsMemberName = "runtimeWorldSpacePanelSettings";
@@ -267,12 +269,105 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         }
     }
 
+    private static void AssignRenderingMode(PanelSettings target, string enumName)
+    {
+        if (string.IsNullOrEmpty(enumName))
+        {
+            throw new ArgumentException("Rendering mode enum name cannot be null or empty.", nameof(enumName));
+        }
+
+        if (TryAssignEnumValue(target, RenderingModeMemberName, enumName))
+        {
+            return;
+        }
+
+        if (TryAssignRenderingModeInContainer(target, RuntimePanelCreationSettingsMemberName, enumName))
+        {
+            return;
+        }
+
+        if (TryAssignRenderingModeInContainer(target, RuntimePanelSettingsMemberName, enumName))
+        {
+            return;
+        }
+
+        throw new MissingMemberException(target.GetType().FullName, RenderingModeMemberName);
+    }
+
     private static void AssignEnumValue(PanelSettings target, string memberName, string enumName)
     {
         if (!TryAssignEnumValue(target, memberName, enumName))
         {
             throw new MissingMemberException(target.GetType().FullName, memberName);
         }
+    }
+
+    private static bool TryAssignRenderingModeInContainer(PanelSettings target, string containerMemberName, string enumName)
+    {
+        if (string.IsNullOrEmpty(containerMemberName))
+        {
+            return false;
+        }
+
+        if (TryAssignRenderingModeOnObject(target, containerMemberName, enumName))
+        {
+            return true;
+        }
+
+        return TryAssignRenderingModeThroughAccessors(target, containerMemberName, enumName);
+    }
+
+    private static bool TryAssignRenderingModeOnObject(object target, string containerMemberName, string enumName)
+    {
+        if (target == null)
+        {
+            return false;
+        }
+
+        var type = target.GetType();
+
+        var property = type.GetProperty(containerMemberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null)
+        {
+            var canRead = property.CanRead;
+            var container = canRead ? property.GetValue(target) : null;
+            if (container == null)
+            {
+                container = CreateContainerInstance(property.PropertyType);
+            }
+
+            if (TryAssignEnumValueOnObject(container, RenderingModeMemberName, enumName))
+            {
+                if (property.CanWrite)
+                {
+                    property.SetValue(target, container);
+                    return true;
+                }
+
+                if (container != null && !property.PropertyType.IsValueType)
+                {
+                    return true;
+                }
+
+                if (TryInvokeContainerSetter(type, containerMemberName, property.PropertyType, container))
+                {
+                    return true;
+                }
+            }
+        }
+
+        var field = type.GetField(containerMemberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null)
+        {
+            var container = field.GetValue(target) ?? CreateContainerInstance(field.FieldType);
+            if (TryAssignEnumValueOnObject(container, RenderingModeMemberName, enumName))
+            {
+                field.SetValue(target, container);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool TryAssignEnumValue(PanelSettings target, string memberName, string enumName)
@@ -368,8 +463,107 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         return false;
     }
 
+    private static bool TryAssignRenderingModeThroughAccessors(object target, string containerMemberName, string enumName)
+    {
+        if (target == null)
+        {
+            return false;
+        }
+
+        var type = target.GetType();
+        var pascalName = ToPascalCase(containerMemberName);
+        if (string.IsNullOrEmpty(pascalName))
+        {
+            return false;
+        }
+
+        var getter = type.GetMethod($"Get{pascalName}", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
+        if (getter == null)
+        {
+            return false;
+        }
+
+        var container = getter.Invoke(target, null);
+        if (!TryAssignEnumValueOnObject(container, RenderingModeMemberName, enumName))
+        {
+            return false;
+        }
+
+        return TryInvokeContainerSetter(type, containerMemberName, getter.ReturnType, container);
+    }
+
+    private static bool TryInvokeContainerSetter(Type targetType, string containerMemberName, Type containerType, object container)
+    {
+        if (targetType == null || containerType == null)
+        {
+            return false;
+        }
+
+        var pascalName = ToPascalCase(containerMemberName);
+        if (string.IsNullOrEmpty(pascalName))
+        {
+            return false;
+        }
+
+        var candidateNames = new[]
+        {
+            $"Set{pascalName}",
+            $"Assign{pascalName}",
+            $"Apply{pascalName}",
+            $"Update{pascalName}"
+        };
+
+        foreach (var methodName in candidateNames)
+        {
+            var method = targetType.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new[] { containerType }, null);
+            if (method != null)
+            {
+                method.Invoke(target, new[] { container });
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ToPascalCase(string memberName)
+    {
+        if (string.IsNullOrEmpty(memberName))
+        {
+            return string.Empty;
+        }
+
+        if (memberName.Length == 1)
+        {
+            return memberName.ToUpperInvariant();
+        }
+
+        return char.ToUpperInvariant(memberName[0]) + memberName.Substring(1);
+    }
+
+    private static object CreateContainerInstance(Type containerType)
+    {
+        if (containerType == null)
+        {
+            return null;
+        }
+
+        if (containerType.IsValueType)
+        {
+            return Activator.CreateInstance(containerType);
+        }
+
+        var constructor = containerType.GetConstructor(Type.EmptyTypes);
+        return constructor != null ? constructor.Invoke(Array.Empty<object>()) : null;
+    }
+
     private static bool TryAssignEnumValueOnObject(object target, string memberName, string enumName)
     {
+        if (target == null)
+        {
+            return false;
+        }
+
         var type = target.GetType();
 
         var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);


### PR DESCRIPTION
## Summary
- update InventoryPanelSettingsAsset to assign the rendering mode through compatibility-aware reflection
- support PanelSettings implementations that expose the runtime panel rendering mode through nested settings containers
- add support for accessor-based runtime settings containers and instantiate missing containers when required

## Testing
- not run (editor-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e433d74a4c832294167bcd12ea89ba