### PR TITLE
Fix container setter invocation helper

### DIFF
--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
@@ -349,7 +349,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
                     return true;
                 }
 
-                if (TryInvokeContainerSetter(type, containerMemberName, property.PropertyType, container))
+                if (TryInvokeContainerSetter(target, containerMemberName, property.PropertyType, container))
                 {
                     return true;
                 }
@@ -489,15 +489,17 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
             return false;
         }
 
-        return TryInvokeContainerSetter(type, containerMemberName, getter.ReturnType, container);
+        return TryInvokeContainerSetter(target, containerMemberName, getter.ReturnType, container);
     }
 
-    private static bool TryInvokeContainerSetter(Type targetType, string containerMemberName, Type containerType, object container)
+    private static bool TryInvokeContainerSetter(object target, string containerMemberName, Type containerType, object container)
     {
-        if (targetType == null || containerType == null)
+        if (target == null || containerType == null)
         {
             return false;
         }
+
+        var targetType = target.GetType();
 
         var pascalName = ToPascalCase(containerMemberName);
         if (string.IsNullOrEmpty(pascalName))


### PR DESCRIPTION
## Summary
- pass the owning panel settings instance into the helper that invokes container setter methods
- update the helper to resolve the target type from the provided instance before invoking setter candidates

## Testing
- `dotnet build Game.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e43a0be6888322927e1f53d3c91f7f