### PR TITLE
Broaden runtime rendering mode assignment

### DIFF
--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
@@ -59,7 +59,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         TryAssignOptional(instance, TargetWidthMemberName, targetWidth);
         TryAssignOptional(instance, TargetHeightMemberName, targetHeight);
         AssignRequired(instance, SortingOrderMemberName, sortingOrder);
-        AssignRenderingMode(instance, GetRuntimePanelRenderingModeName(renderingMode));
+        AssignRenderingMode(instance, renderingMode);
         TryAssignOptional(instance, VsyncCountMemberName, vsyncCount);
         TryAssignOptional(instance, RuntimeShaderMemberName, runtimeShader);
         TryAssignOptional(instance, RuntimeWorldSpacePanelSettingsMemberName, runtimeWorldSpacePanelSettings);
@@ -92,9 +92,23 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
     private const string TargetWidthMemberName = "targetWidth";
     private const string TargetHeightMemberName = "targetHeight";
     private const string SortingOrderMemberName = nameof(PanelSettings.sortingOrder);
-    private const string RenderingModeMemberName = "renderingMode";
-    private const string RuntimePanelCreationSettingsMemberName = "runtimePanelCreationSettings";
-    private const string RuntimePanelSettingsMemberName = "runtimePanelSettings";
+    private static readonly string[] RenderingModeMemberNames =
+    {
+        "renderingMode",
+        "m_RenderingMode"
+    };
+
+    private static readonly string[] RuntimePanelCreationSettingsMemberNames =
+    {
+        "runtimePanelCreationSettings",
+        "m_RuntimePanelCreationSettings"
+    };
+
+    private static readonly string[] RuntimePanelSettingsMemberNames =
+    {
+        "runtimePanelSettings",
+        "m_RuntimePanelSettings"
+    };
     private const string VsyncCountMemberName = "vsyncCount";
     private const string RuntimeShaderMemberName = "runtimeShader";
     private const string RuntimeWorldSpacePanelSettingsMemberName = "runtimeWorldSpacePanelSettings";
@@ -269,29 +283,45 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         }
     }
 
-    private static void AssignRenderingMode(PanelSettings target, string enumName)
+    private static void AssignRenderingMode(PanelSettings target, RuntimePanelRenderingModeOption option)
+    {
+        var enumName = GetRuntimePanelRenderingModeName(option);
+        var numericValue = Convert.ToInt64(option);
+
+        if (TryAssignRenderingModeByName(target, enumName) ||
+            TryAssignRenderingModeByNumericValue(target, numericValue))
+        {
+            return;
+        }
+
+        if (TryAssignRenderingModeInAnyContainerByName(target, enumName) ||
+            TryAssignRenderingModeInAnyContainerByNumericValue(target, numericValue))
+        {
+            return;
+        }
+
+        if (TryAssignRenderingModeBySemanticMatchOnObject(target, enumName, numericValue) ||
+            TryAssignRenderingModeInAllContainersBySemanticMatch(target, enumName, numericValue))
+        {
+            return;
+        }
+
+        throw new MissingMemberException(target.GetType().FullName, RenderingModeMemberNames[0]);
+    }
+
+    private static bool TryAssignRenderingModeByName(PanelSettings target, string enumName)
     {
         if (string.IsNullOrEmpty(enumName))
         {
-            throw new ArgumentException("Rendering mode enum name cannot be null or empty.", nameof(enumName));
+            return false;
         }
 
-        if (TryAssignEnumValue(target, RenderingModeMemberName, enumName))
-        {
-            return;
-        }
+        return TryAssignEnumValueOnObject(target, RenderingModeMemberNames, enumName);
+    }
 
-        if (TryAssignRenderingModeInContainer(target, RuntimePanelCreationSettingsMemberName, enumName))
-        {
-            return;
-        }
-
-        if (TryAssignRenderingModeInContainer(target, RuntimePanelSettingsMemberName, enumName))
-        {
-            return;
-        }
-
-        throw new MissingMemberException(target.GetType().FullName, RenderingModeMemberName);
+    private static bool TryAssignRenderingModeByNumericValue(PanelSettings target, long numericValue)
+    {
+        return TryAssignEnumValueOnObject(target, RenderingModeMemberNames, numericValue);
     }
 
     private static void AssignEnumValue(PanelSettings target, string memberName, string enumName)
@@ -302,24 +332,172 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         }
     }
 
-    private static bool TryAssignRenderingModeInContainer(PanelSettings target, string containerMemberName, string enumName)
+    private static bool TryAssignRenderingModeInAnyContainerByName(PanelSettings target, string enumName)
+    {
+        foreach (var containerName in RuntimePanelCreationSettingsMemberNames)
+        {
+            if (TryAssignRenderingModeInContainerByName(target, containerName, enumName))
+            {
+                return true;
+            }
+        }
+
+        foreach (var containerName in RuntimePanelSettingsMemberNames)
+        {
+            if (TryAssignRenderingModeInContainerByName(target, containerName, enumName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignRenderingModeInAnyContainerByNumericValue(PanelSettings target, long numericValue)
+    {
+        foreach (var containerName in RuntimePanelCreationSettingsMemberNames)
+        {
+            if (TryAssignRenderingModeInContainerByNumericValue(target, containerName, numericValue))
+            {
+                return true;
+            }
+        }
+
+        foreach (var containerName in RuntimePanelSettingsMemberNames)
+        {
+            if (TryAssignRenderingModeInContainerByNumericValue(target, containerName, numericValue))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignRenderingModeBySemanticMatchOnObject(object target, string enumName, long numericValue)
+    {
+        if (target == null)
+        {
+            return false;
+        }
+
+        var type = target.GetType();
+        var members = type.GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        foreach (var member in members)
+        {
+            var canWrite = member switch
+            {
+                PropertyInfo property when property.PropertyType.IsEnum => property.CanWrite,
+                FieldInfo field when field.FieldType.IsEnum => true,
+                _ => false
+            };
+
+            if (!canWrite || !IndicatesRenderingMode(member.Name))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(enumName) && TryAssignEnumValueOnObject(target, member.Name, enumName))
+            {
+                return true;
+            }
+
+            if (TryAssignEnumValueOnObject(target, member.Name, numericValue))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignRenderingModeInAllContainersBySemanticMatch(PanelSettings target, string enumName, long numericValue)
+    {
+        var type = target.GetType();
+
+        foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (!property.CanRead)
+            {
+                continue;
+            }
+
+            var container = property.GetValue(target) ?? CreateContainerInstance(property.PropertyType);
+            if (TryAssignRenderingModeBySemanticMatchOnObject(container, enumName, numericValue))
+            {
+                if (property.CanWrite)
+                {
+                    property.SetValue(target, container);
+                    return true;
+                }
+
+                if (container != null && !property.PropertyType.IsValueType)
+                {
+                    return true;
+                }
+
+                if (TryInvokeContainerSetter(target, property.Name, property.PropertyType, container))
+                {
+                    return true;
+                }
+            }
+        }
+
+        foreach (var field in type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (field.FieldType.IsEnum)
+            {
+                continue;
+            }
+
+            var container = field.GetValue(target) ?? CreateContainerInstance(field.FieldType);
+            if (TryAssignRenderingModeBySemanticMatchOnObject(container, enumName, numericValue))
+            {
+                field.SetValue(target, container);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignRenderingModeInContainerByName(PanelSettings target, string containerMemberName, string enumName)
+    {
+        if (string.IsNullOrEmpty(containerMemberName) || string.IsNullOrEmpty(enumName))
+        {
+            return false;
+        }
+
+        if (TryAssignRenderingModeOnObjectByName(target, containerMemberName, enumName))
+        {
+            return true;
+        }
+
+        return TryAssignRenderingModeThroughAccessorsByName(target, containerMemberName, enumName);
+    }
+
+    private static bool TryAssignRenderingModeInContainerByNumericValue(
+        PanelSettings target,
+        string containerMemberName,
+        long numericValue)
     {
         if (string.IsNullOrEmpty(containerMemberName))
         {
             return false;
         }
 
-        if (TryAssignRenderingModeOnObject(target, containerMemberName, enumName))
+        if (TryAssignRenderingModeOnObjectByNumericValue(target, containerMemberName, numericValue))
         {
             return true;
         }
 
-        return TryAssignRenderingModeThroughAccessors(target, containerMemberName, enumName);
+        return TryAssignRenderingModeThroughAccessorsByNumericValue(target, containerMemberName, numericValue);
     }
 
-    private static bool TryAssignRenderingModeOnObject(object target, string containerMemberName, string enumName)
+    private static bool TryAssignRenderingModeOnObjectByName(object target, string containerMemberName, string enumName)
     {
-        if (target == null)
+        if (target == null || string.IsNullOrEmpty(containerMemberName) || string.IsNullOrEmpty(enumName))
         {
             return false;
         }
@@ -336,7 +514,7 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
                 container = CreateContainerInstance(property.PropertyType);
             }
 
-            if (TryAssignEnumValueOnObject(container, RenderingModeMemberName, enumName))
+            if (TryAssignEnumValueOnObject(container, RenderingModeMemberNames, enumName))
             {
                 if (property.CanWrite)
                 {
@@ -360,7 +538,60 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         if (field != null)
         {
             var container = field.GetValue(target) ?? CreateContainerInstance(field.FieldType);
-            if (TryAssignEnumValueOnObject(container, RenderingModeMemberName, enumName))
+            if (TryAssignEnumValueOnObject(container, RenderingModeMemberNames, enumName))
+            {
+                field.SetValue(target, container);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignRenderingModeOnObjectByNumericValue(object target, string containerMemberName, long numericValue)
+    {
+        if (target == null || string.IsNullOrEmpty(containerMemberName))
+        {
+            return false;
+        }
+
+        var type = target.GetType();
+
+        var property = type.GetProperty(containerMemberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null)
+        {
+            var canRead = property.CanRead;
+            var container = canRead ? property.GetValue(target) : null;
+            if (container == null)
+            {
+                container = CreateContainerInstance(property.PropertyType);
+            }
+
+            if (TryAssignEnumValueOnObject(container, RenderingModeMemberNames, numericValue))
+            {
+                if (property.CanWrite)
+                {
+                    property.SetValue(target, container);
+                    return true;
+                }
+
+                if (container != null && !property.PropertyType.IsValueType)
+                {
+                    return true;
+                }
+
+                if (TryInvokeContainerSetter(target, containerMemberName, property.PropertyType, container))
+                {
+                    return true;
+                }
+            }
+        }
+
+        var field = type.GetField(containerMemberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null)
+        {
+            var container = field.GetValue(target) ?? CreateContainerInstance(field.FieldType);
+            if (TryAssignEnumValueOnObject(container, RenderingModeMemberNames, numericValue))
             {
                 field.SetValue(target, container);
                 return true;
@@ -390,6 +621,28 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         if (field != null)
         {
             var value = CreateEnumValue(field.FieldType, enumName, memberName);
+            field.SetValue(target, value);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignEnumValue(PanelSettings target, string memberName, long numericValue)
+    {
+        var type = target.GetType();
+        var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null && property.CanWrite && property.PropertyType.IsEnum)
+        {
+            var value = CreateEnumValue(property.PropertyType, numericValue, memberName);
+            property.SetValue(target, value);
+            return true;
+        }
+
+        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null && field.FieldType.IsEnum)
+        {
+            var value = CreateEnumValue(field.FieldType, numericValue, memberName);
             field.SetValue(target, value);
             return true;
         }
@@ -463,9 +716,9 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         return false;
     }
 
-    private static bool TryAssignRenderingModeThroughAccessors(object target, string containerMemberName, string enumName)
+    private static bool TryAssignRenderingModeThroughAccessorsByName(object target, string containerMemberName, string enumName)
     {
-        if (target == null)
+        if (target == null || string.IsNullOrEmpty(containerMemberName) || string.IsNullOrEmpty(enumName))
         {
             return false;
         }
@@ -484,7 +737,36 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         }
 
         var container = getter.Invoke(target, null);
-        if (!TryAssignEnumValueOnObject(container, RenderingModeMemberName, enumName))
+        if (!TryAssignEnumValueOnObject(container, RenderingModeMemberNames, enumName))
+        {
+            return false;
+        }
+
+        return TryInvokeContainerSetter(target, containerMemberName, getter.ReturnType, container);
+    }
+
+    private static bool TryAssignRenderingModeThroughAccessorsByNumericValue(object target, string containerMemberName, long numericValue)
+    {
+        if (target == null || string.IsNullOrEmpty(containerMemberName))
+        {
+            return false;
+        }
+
+        var type = target.GetType();
+        var pascalName = ToPascalCase(containerMemberName);
+        if (string.IsNullOrEmpty(pascalName))
+        {
+            return false;
+        }
+
+        var getter = type.GetMethod($"Get{pascalName}", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, Type.EmptyTypes, null);
+        if (getter == null)
+        {
+            return false;
+        }
+
+        var container = getter.Invoke(target, null);
+        if (!TryAssignEnumValueOnObject(container, RenderingModeMemberNames, numericValue))
         {
             return false;
         }
@@ -559,6 +841,40 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         return constructor != null ? constructor.Invoke(Array.Empty<object>()) : null;
     }
 
+    private static bool IndicatesRenderingMode(string memberName)
+    {
+        if (string.IsNullOrEmpty(memberName))
+        {
+            return false;
+        }
+
+        var lowered = memberName.ToLowerInvariant();
+        if (lowered.Contains("renderingmode") || lowered.Contains("renderermode"))
+        {
+            return true;
+        }
+
+        return lowered.Contains("render") && lowered.Contains("mode");
+    }
+
+    private static bool TryAssignEnumValueOnObject(object target, string[] memberNames, string enumName)
+    {
+        if (target == null || memberNames == null)
+        {
+            return false;
+        }
+
+        foreach (var memberName in memberNames)
+        {
+            if (TryAssignEnumValueOnObject(target, memberName, enumName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool TryAssignEnumValueOnObject(object target, string memberName, string enumName)
     {
         if (target == null)
@@ -587,6 +903,52 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         return false;
     }
 
+    private static bool TryAssignEnumValueOnObject(object target, string[] memberNames, long numericValue)
+    {
+        if (target == null || memberNames == null)
+        {
+            return false;
+        }
+
+        foreach (var memberName in memberNames)
+        {
+            if (TryAssignEnumValueOnObject(target, memberName, numericValue))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryAssignEnumValueOnObject(object target, string memberName, long numericValue)
+    {
+        if (target == null)
+        {
+            return false;
+        }
+
+        var type = target.GetType();
+
+        var property = type.GetProperty(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (property != null && property.CanWrite && property.PropertyType.IsEnum)
+        {
+            var value = CreateEnumValue(property.PropertyType, numericValue, memberName);
+            property.SetValue(target, value);
+            return true;
+        }
+
+        var field = type.GetField(memberName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        if (field != null && field.FieldType.IsEnum)
+        {
+            var value = CreateEnumValue(field.FieldType, numericValue, memberName);
+            field.SetValue(target, value);
+            return true;
+        }
+
+        return false;
+    }
+
     private static object CreateEnumValue(Type enumType, string enumName, string memberName)
     {
         if (!enumType.IsEnum)
@@ -602,6 +964,22 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
         {
             throw new InvalidOperationException($"Value '{enumName}' is not defined for enum '{enumType.FullName}'.", exception);
         }
+    }
+
+    private static object CreateEnumValue(Type enumType, long numericValue, string memberName)
+    {
+        if (!enumType.IsEnum)
+        {
+            throw new InvalidOperationException($"Member '{memberName}' on '{enumType.FullName}' is not an enum.");
+        }
+
+        var value = Enum.ToObject(enumType, numericValue);
+        if (!Enum.IsDefined(enumType, value))
+        {
+            throw new InvalidOperationException($"Value '{numericValue}' is not defined for enum '{enumType.FullName}'.");
+        }
+
+        return value;
     }
 
     private static void TryAssignTargetLayerMask(PanelSettings target, LayerMask mask)


### PR DESCRIPTION
## Summary
- add support for alternative rendering mode member and container names when cloning panel settings
- fall back to semantic matching so rendering mode enums can be set even when Unity changes member layouts

## Testing
- Not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e43af4efa483228d2fd3b66cb3e606