### PR TITLE
Handle renamed panel render mode values

### DIFF
--- a/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
+++ b/Assets/Scripts/UI/InventoryPanelSettingsAsset.cs
@@ -983,10 +983,36 @@ public sealed class InventoryPanelSettingsAsset : ScriptableObject
             return false;
         }
 
-        if (string.Equals(enumName, "Camera", StringComparison.Ordinal) &&
-            Enum.IsDefined(enumType, "ScreenSpaceCamera"))
+        if (string.Equals(enumName, "Camera", StringComparison.Ordinal))
         {
-            resolvedName = "ScreenSpaceCamera";
+            if (Enum.IsDefined(enumType, "ScreenSpaceCamera"))
+            {
+                resolvedName = "ScreenSpaceCamera";
+                return true;
+            }
+
+            if (Enum.IsDefined(enumType, "RuntimeCamera"))
+            {
+                resolvedName = "RuntimeCamera";
+                return true;
+            }
+
+            foreach (var candidate in Enum.GetNames(enumType))
+            {
+                if (candidate.IndexOf("Camera", StringComparison.Ordinal) >= 0)
+                {
+                    resolvedName = candidate;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (string.Equals(enumName, "Overlay", StringComparison.Ordinal) &&
+            Enum.IsDefined(enumType, "ScreenSpaceOverlay"))
+        {
+            resolvedName = "ScreenSpaceOverlay";
             return true;
         }
 


### PR DESCRIPTION
## Summary
- broaden the panel render mode alias resolution so legacy "Camera" values map to whichever camera-named value exists
- add an additional alias to translate legacy "Overlay" values when only the ScreenSpaceOverlay name is available

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e443f46de08322a5897aefd3f07e49