### PR TITLE
Create inventory UI hierarchy with panel settings

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -210,7 +210,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 100051}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &100004
@@ -496,8 +497,78 @@ MonoBehaviour:
   m_EditorClassIdentifier:
   bootstrapper: {fileID: 100022}
   pawnContainer: {fileID: 0}
+  observerCamera: {fileID: 100002}
+  playerPawnController: {fileID: 100042}
+  inventoryGridPresenter: {fileID: 100053}
   mapSortingOrder: -100
   pawnSortingOrder: 0
+--- !u!1 &100050
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 100051}
+  - component: {fileID: 100052}
+  - component: {fileID: 100053}
+  m_Layer: 0
+  m_Name: UI.Inventory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &100051
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100050}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 100031}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &100052
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3fa96904056d41b9ab0f07f805ddc3a, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  panelSettings: {fileID: 11400000, guid: c2ed32028b5446f587af5a7a9bcbd6bb, type: 2}
+  visualTree: {fileID: 9197481963314157269, guid: 61b28feda869424ea54c05e799090248, type: 3}
+--- !u!114 &100053
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b745f318714455b96ad2a8125aa4d12, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bootstrapper: {fileID: 100022}
+  simulationView: {fileID: 100032}
+  panelSettings: {fileID: 11400000, guid: c2ed32028b5446f587af5a7a9bcbd6bb, type: 2}
+  columns: 4
+  slotSize: 40
+  panelOffset: {x: 16, y: 280}
+  refreshInterval: 0.25
+  fallbackCapacity: 12
 --- !u!1 &100040
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GoapSimulationView.cs
+++ b/Assets/Scripts/GoapSimulationView.cs
@@ -3175,8 +3175,13 @@ public sealed class GoapSimulationView : MonoBehaviour
 
         if (inventoryGridPresenter == null)
         {
+            inventoryGridPresenter = GetComponentInChildren<InventoryGridPresenter>(includeInactive: true);
+        }
+
+        if (inventoryGridPresenter == null)
+        {
             throw new InvalidOperationException(
-                "GoapSimulationView requires an InventoryGridPresenter assigned in the inspector.");
+                "GoapSimulationView requires an InventoryGridPresenter component in the hierarchy.");
         }
 
         inventoryGridPresenter.ConfigureDependencies(bootstrapper, this);

--- a/Assets/Scripts/UI/InventoryUIDocumentAuthoring.cs
+++ b/Assets/Scripts/UI/InventoryUIDocumentAuthoring.cs
@@ -1,0 +1,33 @@
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+[DisallowMultipleComponent]
+[RequireComponent(typeof(UIDocument))]
+public sealed class InventoryUIDocumentAuthoring : MonoBehaviour
+{
+    [SerializeField] private PanelSettings panelSettings;
+    [SerializeField] private VisualTreeAsset visualTree;
+
+    private void Awake()
+    {
+        var document = GetComponent<UIDocument>();
+        if (document == null)
+        {
+            throw new InvalidOperationException("InventoryUIDocumentAuthoring requires a UIDocument component.");
+        }
+
+        if (panelSettings == null)
+        {
+            throw new InvalidOperationException("InventoryUIDocumentAuthoring requires a PanelSettings asset reference.");
+        }
+
+        if (visualTree == null)
+        {
+            throw new InvalidOperationException("InventoryUIDocumentAuthoring requires a VisualTreeAsset reference.");
+        }
+
+        document.panelSettings = panelSettings;
+        document.visualTreeAsset = visualTree;
+    }
+}

--- a/Assets/Scripts/UI/InventoryUIDocumentAuthoring.cs.meta
+++ b/Assets/Scripts/UI/InventoryUIDocumentAuthoring.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fa96904056d41b9ab0f07f805ddc3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UI/Inventory/InventoryPanelSettings.asset
+++ b/Assets/UI/Inventory/InventoryPanelSettings.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 976c4357e90cd274fbf5f6b2bc2f2e17, type: 3}
+  m_Name: InventoryPanelSettings
+  m_EditorClassIdentifier:
+  targetTexture: {fileID: 0}
+  scaleMode: 1
+  referenceResolution: {x: 1920, y: 1080}
+  screenMatchMode: 0
+  match: 0
+  pixelsPerPoint: 1
+  clearDepthStencil: 1
+  clearColor: 0
+  colorClearValue: {r: 0, g: 0, b: 0, a: 0}
+  depthClearValue: 1
+  sortingMode: 0
+  targetDisplay: 0
+  sortingOrder: 0
+  vsync: 0
+  targetLayer: 0
+  scale: 1
+  referenceDpi: 96
+  referenceScale: 1
+  textSettings: {fileID: 0}
+  atlasBlitShader: {fileID: 0}
+  runtimeShader: {fileID: 0}
+  vectorImageShader: {fileID: 0}

--- a/Assets/UI/Inventory/InventoryPanelSettings.asset.meta
+++ b/Assets/UI/Inventory/InventoryPanelSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c2ed32028b5446f587af5a7a9bcbd6bb
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add an Inventory UIDocument authoring script that configures panel settings and the inventory visual tree at runtime
- create an InventoryPanelSettings asset and hook a UI.Inventory object into GoapSimulationScene so GoapSimulationView references the presenter

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e44a902b308322a15ebd5852f861c0