### PR TITLE
Fix invalid child transform relationship in GoapSimulationScene

### DIFF
--- a/Assets/Scenes/GoapSimulationScene.unity
+++ b/Assets/Scenes/GoapSimulationScene.unity
@@ -210,8 +210,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 100051}
+  m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &100004


### PR DESCRIPTION
## Summary
- clear the Main Camera's child list so the UI inventory transform is only parented to the simulation view

## Testing
- not run (Unity editor only change)


------
https://chatgpt.com/codex/tasks/task_e_68e45097b86083228c7796c1f950508e